### PR TITLE
Fix a bunch of issues on clean machines since the export

### DIFF
--- a/scripts/initial_setup.bat
+++ b/scripts/initial_setup.bat
@@ -9,12 +9,12 @@ if errorlevel 9009 (
 )
 
 :: Check if the virtual environment already exists
-if exist venv (
+if exist .venv (
     echo Virtual environment already exists. Skipping creation.
 ) else (
     :: Create a virtual environment
     echo Creating virtual environment.
-    python -m venv venv
+    python -m .venv venv
     if errorlevel 1 (
         echo Failed to create a virtual environment.
         exit /b 1
@@ -23,7 +23,7 @@ if exist venv (
 
 :: Activate the virtual environment
 echo Activating virtual environment.
-CALL venv\scripts\activate.bat
+CALL .venv\scripts\activate.bat
 if errorlevel 1 (
     echo Failed to activate the virtual environment.
     exit /b 1
@@ -40,5 +40,5 @@ if errorlevel 1 (
 
 
 echo Initial setup completed successfully.
-echo Remember to activate the virtual environment with 'venv\scripts\activate.bat' before you start working.
+echo Remember to activate the virtual environment with ',venv\scripts\activate.bat' before you start working.
 ENDLOCAL

--- a/scripts/initial_setup.sh
+++ b/scripts/initial_setup.sh
@@ -8,22 +8,22 @@ if ! command -v python &> /dev/null; then
 fi
 
 # Check if the virtual environment already exists
-if [ -d "venv" ]; then
+if [ -d ".venv" ]; then
     echo "Virtual environment already exists. Skipping creation."
 else
     echo "Creating virtual environment"
     # Create a virtual environment
-    python -m venv venv
+    python -m .venv venv
 fi
 
 # Activate the virtual environment
 echo "Activating virtual environment"
-source venv/bin/activate
+source .venv/bin/activate
 
 # Install the requirements
 echo "Installing deps"
 chmod a+x scripts/install_deps.sh
 ./scripts/install_deps.sh
-echo "Remember to activate the virtual environment with 'source venv/bin/activate' before you start working."
+echo "Remember to activate the virtual environment with 'source .venv/bin/activate' before you start working."
 
 # Exit from the script without deactivating (since it's a new shell instance)

--- a/src/agent_c_reference_apps/pyproject.toml
+++ b/src/agent_c_reference_apps/pyproject.toml
@@ -5,14 +5,12 @@ description = "Demo applications for written using Agent C"
 dependencies = [
     "agent_c-core>=0.1.1",
     "agent_c-tools>=0.1.1",
-    "agent_c-demo>=0.1.1",
-    "agent_c-voice>=0.1.1",
-    "agent_c-rag>=0.1.1",
-    "agent_c-vision>=0.1.1",
-    "agent_c-extraction>=0.1.1",
     "gradio==5.5.0",
     "rich==13.8.1",
-    "prompt_toolkit>=3.0.43"
+    "prompt_toolkit>=3.0.43",
+    "python-dotenv",
+    "spacy==3.8.3",
+    "pyaudio"
 ]
 
 requires-python = ">=3.10"

--- a/src/agent_c_reference_apps/src/agent_c_reference_apps/agent_c_gradio.py
+++ b/src/agent_c_reference_apps/src/agent_c_reference_apps/agent_c_gradio.py
@@ -9,10 +9,6 @@ load_dotenv(override=True)
 
 # Ensure all our toolsets get registered
 from agent_c_tools.tools import *  # noqa
-from agent_c_demo.tools import *  # noqa
-from agent_c_voice.tools import *  # noqa
-from agent_c_rag.tools import *  # noqa
-
 from agent_c_reference_apps.ui.gradio_ui import GradioChat
 
 

--- a/src/agent_c_tools/pyproject.toml
+++ b/src/agent_c_tools/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "aiohttp==3.10.10",# web_search-seeking_alpha
     "tavily-python==0.5.0", # web_search-tavily
     "wikipedia==1.4.0",    # web_search-wikipedia
+    "lxml_html_clean"
 ]
 
 requires-python = ">=3.10"


### PR DESCRIPTION
This pull request includes several changes to the setup scripts and the `agent_c_reference_apps` project to improve virtual environment handling and remove unused dependencies.

### Virtual Environment Handling:
* [`scripts/initial_setup.bat`](diffhunk://#diff-9f0788522d27598f85ee067fbc160a216a9356615e2117c4f2672f8256de9735L12-R17): Changed virtual environment directory from `venv` to `.venv` and updated related commands. [[1]](diffhunk://#diff-9f0788522d27598f85ee067fbc160a216a9356615e2117c4f2672f8256de9735L12-R17) [[2]](diffhunk://#diff-9f0788522d27598f85ee067fbc160a216a9356615e2117c4f2672f8256de9735L26-R26) [[3]](diffhunk://#diff-9f0788522d27598f85ee067fbc160a216a9356615e2117c4f2672f8256de9735L43-R43)
* [`scripts/initial_setup.sh`](diffhunk://#diff-4c93955ef4d8c9650aef19be7fd7da249d9160dffbb287ef04c4f906c57d1948L11-R27): Changed virtual environment directory from `venv` to `.venv` and updated related commands.

### Dependency Management:
* [`src/agent_c_reference_apps/pyproject.toml`](diffhunk://#diff-3794f65909e68f4d1302f622f62ccb20de491100c77cd1cbd4969fa23d40adf3L8-R13): Added new dependencies `python-dotenv`, `spacy==3.8.3`, and `pyaudio`. Removed unused dependencies `agent_c-demo`, `agent_c-voice`, `agent_c-rag`, `agent_c-vision`, and `agent_c-extraction`.
* [`src/agent_c_tools/pyproject.toml`](diffhunk://#diff-e2be9e2d1a83ee0209dfa14a698162dc18640a4b9d8e81370790e570e20f28bbR26): Added `lxml_html_clean` dependency.

### Codebase Cleanup:
* [`src/agent_c_reference_apps/src/agent_c_reference_apps/agent_c_gradio.py`](diffhunk://#diff-9cfed25a450f0558f7b9aa71f2d3b7efa5cf7250ab41a5c94f1bb70e39891eccL12-L15): Removed unused imports related to `agent_c_demo`, `agent_c_voice`, and `agent_c_rag`.
* [`src/agent_c_reference_apps/src/agent_c_reference_apps/ui/gradio_ui.py`](diffhunk://#diff-d5b981a8dfcdbe0d87d7dea65f9a6a8ae5a0b9c5bd938caf9c1fdc1a320fea29L31-R49): Commented out or removed code related to TTS, transcription, and camera initialization, simplifying the class. [[1]](diffhunk://#diff-d5b981a8dfcdbe0d87d7dea65f9a6a8ae5a0b9c5bd938caf9c1fdc1a320fea29L31-R49) [[2]](diffhunk://#diff-d5b981a8dfcdbe0d87d7dea65f9a6a8ae5a0b9c5bd938caf9c1fdc1a320fea29L111-L115) [[3]](diffhunk://#diff-d5b981a8dfcdbe0d87d7dea65f9a6a8ae5a0b9c5bd938caf9c1fdc1a320fea29L147-L176) [[4]](diffhunk://#diff-d5b981a8dfcdbe0d87d7dea65f9a6a8ae5a0b9c5bd938caf9c1fdc1a320fea29L232-L240) [[5]](diffhunk://#diff-d5b981a8dfcdbe0d87d7dea65f9a6a8ae5a0b9c5bd938caf9c1fdc1a320fea29L255-L260) [[6]](diffhunk://#diff-d5b981a8dfcdbe0d87d7dea65f9a6a8ae5a0b9c5bd938caf9c1fdc1a320fea29L682-R634) [[7]](diffhunk://#diff-d5b981a8dfcdbe0d87d7dea65f9a6a8ae5a0b9c5bd938caf9c1fdc1a320fea29L695-L699) [[8]](diffhunk://#diff-d5b981a8dfcdbe0d87d7dea65f9a6a8ae5a0b9c5bd938caf9c1fdc1a320fea29L726-L740) [[9]](diffhunk://#diff-d5b981a8dfcdbe0d87d7dea65f9a6a8ae5a0b9c5bd938caf9c1fdc1a320fea29L875-L877) [[10]](diffhunk://#diff-d5b981a8dfcdbe0d87d7dea65f9a6a8ae5a0b9c5bd938caf9c1fdc1a320fea29L951-R879) [[11]](diffhunk://#diff-d5b981a8dfcdbe0d87d7dea65f9a6a8ae5a0b9c5bd938caf9c1fdc1a320fea29L967-L979)