### PR TITLE
Support for GPT-4o and GPT-4o-preview as agents

### DIFF
--- a/example.env
+++ b/example.env
@@ -2,6 +2,8 @@
 OPENAI_API_KEY="FROM OPEN AI"
 MODEL_NAME="gpt-4o"
 
+#ROOT_MESSAGE_ROLE="developer"  # uncomment this if using a model other than GPT-4o that uses a different root message name from 'system'
+
 # o1 Agent specific keys
 # O1_AGENT_APIKEY="o1 available API Key"
 # O1_MODEL="o1-preview" # or "o1-mini"
@@ -11,7 +13,7 @@ MODEL_NAME="gpt-4o"
 AZURE_OPENAI_API_KEY="FROM AZURE"
 AZURE_OPENAI_ENDPOINT="https://YOURNAME.openai.azure.com/"
 AZURE_OPENAI_MODEL="YOURMODEL"
-#AZURE_OPENAI_API_VERSION="2024-03-01-preview"
+AZURE_OPENAI_API_VERSION="2024-03-01-preview"
 
 # Needed for Claude support
 #ANTHROPIC_API_KEY="FROM ANTHROPIC"

--- a/src/agent_c_core/pyproject.toml
+++ b/src/agent_c_core/pyproject.toml
@@ -8,7 +8,7 @@ name = "agent_c-core"
 version = "0.1.1"
 dependencies = [
     "pydantic==2.9.2",
-    "openai==1.58.1",
+    "openai==1.59.7",
     "tiktoken==0.7.0",
     "anthropic==0.34.2",
     "diskcache==5.6.3",

--- a/src/agent_c_core/src/agent_c/agents/base.py
+++ b/src/agent_c_core/src/agent_c/agents/base.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 from asyncio import Semaphore
 from typing import Any, Dict, List, Union, Optional, Callable, Awaitable
 
@@ -55,6 +56,7 @@ class BaseAgent:
         self.can_use_tools: bool = False
         self.supports_multimodal: bool = False
         self.token_counter: TokenCounter = kwargs.get("token_counter", TokenCounter())
+        self.root_message_role: str =  kwargs.get( "root_message_role", os.environ.get("ROOT_MESSAGE_ROLE", "system"))
 
         if TokenCounter.counter() is None:
             TokenCounter.set_counter(self.token_counter)
@@ -213,7 +215,7 @@ class BaseAgent:
         message_array: List[dict[str, Any]] = []
 
         if sys_prompt is not None:
-            message_array.append({"role": "system", "content": sys_prompt})
+            message_array.append({"role": self.root_message_role, "content": sys_prompt})
 
         if messages is not None:
             message_array += messages

--- a/src/agent_c_core/src/agent_c/agents/gpt.py
+++ b/src/agent_c_core/src/agent_c/agents/gpt.py
@@ -61,6 +61,11 @@ class GPTChatAgent(BaseAgent):
         self.can_use_tools = True
         self.supports_multimodal = True
 
+        # Temporary until all the models support this
+        if self.model_name in ["gpt-o1", 'gpt-o1-mini']:
+            self.root_message_role = "developer"
+
+
     def _generate_multi_modal_user_message(self, user_input: str, images: List[ImageInput]) -> Union[List[dict[str, Any]], None]:
         if self.mitigate_image_prompt_injection:
             text = f"User: {user_input}{BaseAgent.IMAGE_PI_MITIGATION}"
@@ -129,6 +134,8 @@ class GPTChatAgent(BaseAgent):
         user = kwargs.get("user_name", None)
         if user is not None:
             completion_opts["user"] = user
+
+
 
         return {'completion_opts':completion_opts, 'callback_opts': self._callback_opts(**kwargs)}
 


### PR DESCRIPTION
This pull request includes several changes to the `agent_c_core` module and configuration files to enhance the flexibility of the root message role and update dependencies. The most important changes include the addition of a new environment variable, updates to dependencies, and modifications to accommodate different root message roles.

Configuration updates:

* [`example.env`](diffhunk://#diff-a714eca19b6f8db4dbfbd978aa5325b98cc0550fe4c1e7953e8b1eb136cb925aR5-R6): Added a new environment variable `ROOT_MESSAGE_ROLE` to allow customization of the root message role when using models other than GPT-4o.
* [`example.env`](diffhunk://#diff-a714eca19b6f8db4dbfbd978aa5325b98cc0550fe4c1e7953e8b1eb136cb925aL14-R16): Uncommented `AZURE_OPENAI_API_VERSION` to enable its usage.

Dependency updates:

* [`src/agent_c_core/pyproject.toml`](diffhunk://#diff-76974589e64d56ea3dd561ad76276387e14b3016e8fdc106bf6288f890b0e5b4L11-R11): Updated the `openai` dependency from version `1.58.1` to `1.59.7`.

Codebase enhancements:

* [`src/agent_c_core/src/agent_c/agents/base.py`](diffhunk://#diff-05d594b58857c6a5387e2d9eb11eee0f362be65f9681840f327422756c820a77R3): Added `root_message_role` attribute to the `BaseAgent` class, allowing it to be set via environment variable or defaulting to "system". Updated the `__construct_message_array` method to use this attribute. [[1]](diffhunk://#diff-05d594b58857c6a5387e2d9eb11eee0f362be65f9681840f327422756c820a77R3) [[2]](diffhunk://#diff-05d594b58857c6a5387e2d9eb11eee0f362be65f9681840f327422756c820a77R59) [[3]](diffhunk://#diff-05d594b58857c6a5387e2d9eb11eee0f362be65f9681840f327422756c820a77L216-R218)
* [`src/agent_c_core/src/agent_c/agents/gpt.py`](diffhunk://#diff-0b0b2a2155f664049de21c3c667705f1c11a5613fc2949087029caaff07e36cfR64-R68): Temporarily set the `root_message_role` to "developer" for specific models (`gpt-o1`, `gpt-o1-mini`).