### PR TITLE
Fix Toolman to use my_agent_c as a target not agent_c_demo.

### DIFF
--- a/personas/toolman.md
+++ b/personas/toolman.md
@@ -32,15 +32,6 @@ General guidelines:
                     - utils/
                 - pyproject.toml
                 - setup.py
-          - agent_c_demo
-            - src
-              - agent_c_demo
-                - prompting/
-                - tools/
-                  - __init__.py
-              - pyproject.toml
-              - setup.py
-              - __init__.py
           - agent_c_reference_apps
             - src
               - agent_c_reference_apps
@@ -59,6 +50,13 @@ General guidelines:
                 - __init__.py
               - pyproject.toml
               - setup.py
+          - my_agent_c
+            - src
+              - my_agent_c
+                - tools/
+                - __init__.py
+              - pyproject.toml
+              - setup.py
                 
                   
 - All paths are relative and sandboxed to the root of the workspace.
@@ -69,14 +67,14 @@ General guidelines:
 
 
 ### Source conventions:
-- Source for tools belongs in the `src/agent_c/demo` folder
-- The source folder name for a tool belt should be in snake case and exclude the word `tool`. The filename will be tool.py.  So `WeatherTools` file will be called `tool.py` in the `weather` folder such as: `src/agent_c_demo/src/agent_c_demo/tools/weather/tool.py`
+- Source for tools belongs in the `my_agent_c/tools` folder
+- The source folder name for a tool belt should be in snake case and exclude the word `tool`. The filename will be tool.py.  So `WeatherTools` file will be called `tool.py` in the `weather` folder such as: `src/my_agent_c/src/my_agent_c/tools/weather/tool.py`
 - When adding a new tool belt you must complete 4 tasks
-  - create an __init.py__ file in the tool folder like `src/agent_c_demo/src/agent_c_demo/tools/weather/__init__.py`and add an import to file such as `from agent_c_demo.tools.weather.tool import WeatherTools`
-  - Also append a wildcard import to agent_c_demo folder `src/agent_c_demo/src/agent_c_demo/tools/__init__.py` like this `from agent_c_demo.tools.weather import *` and add a newline after the import statement.
-  - Read the folder `src/agent_c_demo/src/pyproject.toml` and append any new libraries to the `pyproject.toml` file.
+  - create an __init.py__ file in the tool folder like `src/agent_c_demo/src/my_agent_c/tools/weather/__init__.py`and add an import to file such as `from my_agent_c.tools.weather.tool import WeatherTools`
+  - Also append a wildcard import to agent_c_demo folder `src/my_agent_c/src/my_agent_c/tools/__init__.py` like this `from my_agent_c.tools.weather import *` and add a newline after the import statement.
+  - Read the folder `src/my_agent_c/src/pyproject.toml` and append any new libraries to the `pyproject.toml` file.
   - Inform the user of the changes made - e.g. files written and files modified
-  - Inform the user to re-run the `pip install -e agent_c_demo` command projects virtual environment.
+  - Inform the user to re-run the `pip install -e my_agent_c` command projects virtual environment.
 
 ## How custom tools work
 

--- a/scripts/install_deps.bat
+++ b/scripts/install_deps.bat
@@ -6,6 +6,7 @@ echo Installing dependencies.
 cd src
 pip install -e agent_c_core
 pip install -e agent_c_tools
+pip install -e my_agent_c
 pip install -e agent_c_reference_apps
 
 

--- a/scripts/install_deps.sh
+++ b/scripts/install_deps.sh
@@ -5,6 +5,7 @@ echo "Installing deps"
 cd src
 pip install -e agent_c_core
 pip install -e agent_c_tools
+pip install -e my_agent_c
 pip install -e agent_c_reference_apps
 
 

--- a/src/agent_c_reference_apps/src/agent_c_reference_apps/agent_c_gradio.py
+++ b/src/agent_c_reference_apps/src/agent_c_reference_apps/agent_c_gradio.py
@@ -10,7 +10,7 @@ load_dotenv(override=True)
 # Ensure all our toolsets get registered
 from agent_c_tools.tools import *  # noqa
 from agent_c_reference_apps.ui.gradio_ui import GradioChat
-
+from my_agent_c.tools import *  # noqa
 
 
 def main():

--- a/src/my_agent_c/pyproject.toml
+++ b/src/my_agent_c/pyproject.toml
@@ -4,13 +4,7 @@ version = "0.1.1"
 description = "Your personal playground for Agent C stuff"
 dependencies = [
     "agent_c-core>=0.1.1",
-    "agent_c-tools>=0.1.1",
-    "agent_c-demo>=0.1.1",
-    "agent_c-voice>=0.1.1",
-    "agent_c-rag>=0.1.1",
-    "agent_c-vision>=0.1.1",
-    "agent_c-reference-apps>=0.1.1",
-    "agent_c-extraction>=0.1.1",
+    "agent_c-tools>=0.1.1"
 ]
 requires-python = ">=3.10"
 authors = [

--- a/src/my_agent_c/src/my_agent_c/tools/__init__.py
+++ b/src/my_agent_c/src/my_agent_c/tools/__init__.py
@@ -1,1 +1,0 @@
-from my_agent_c.tools.disk_space import *

--- a/src/my_agent_c/src/my_agent_c/tools/__init__.py
+++ b/src/my_agent_c/src/my_agent_c/tools/__init__.py
@@ -1,0 +1,1 @@
+from my_agent_c.tools.disk_space import *


### PR DESCRIPTION
This pull request introduces a new project structure for `my_agent_c` and updates various files to reflect this addition. The most important changes include updating the general guidelines, installation scripts, and dependencies to incorporate `my_agent_c`.

### Updates to project structure and guidelines:

* [`personas/toolman.md`](diffhunk://#diff-e6955afc5ca665d0be3aea31d28aec810be9dca3ae008f51d0904afafd76fadfL35-L43): Added `my_agent_c` to the project structure and updated the source conventions to reflect the new folder structure. [[1]](diffhunk://#diff-e6955afc5ca665d0be3aea31d28aec810be9dca3ae008f51d0904afafd76fadfL35-L43) [[2]](diffhunk://#diff-e6955afc5ca665d0be3aea31d28aec810be9dca3ae008f51d0904afafd76fadfR53-R59) [[3]](diffhunk://#diff-e6955afc5ca665d0be3aea31d28aec810be9dca3ae008f51d0904afafd76fadfL72-R77)

### Updates to installation scripts:

* [`scripts/install_deps.bat`](diffhunk://#diff-de915ec606b4024bd7beb0a6bf618972b0a3fce3ff57b417627a1b5a41ba2852R9): Added `my_agent_c` to the list of dependencies to be installed.
* [`scripts/install_deps.sh`](diffhunk://#diff-c3ff4e129c54b291da6bdad23c8664c34a78325e7c02e8c13404041836bb82d6R8): Added `my_agent_c` to the list of dependencies to be installed.

### Updates to dependencies:

* [`src/agent_c_reference_apps/src/agent_c_reference_apps/agent_c_gradio.py`](diffhunk://#diff-9cfed25a450f0558f7b9aa71f2d3b7efa5cf7250ab41a5c94f1bb70e39891eccL13-R13): Added import statement for `my_agent_c.tools`.
* [`src/my_agent_c/pyproject.toml`](diffhunk://#diff-7774e31f6222cd124a02d6ca75c2e5735d1a6db1a12dbfbef262173fd921c200L7-R7): Updated dependencies to include only `agent_c-tools`.