### PR TITLE
add o3 to the list of models that use developer messages.

### DIFF
--- a/src/agent_c_core/src/agent_c/agents/gpt.py
+++ b/src/agent_c_core/src/agent_c/agents/gpt.py
@@ -62,7 +62,7 @@ class GPTChatAgent(BaseAgent):
         self.supports_multimodal = True
 
         # Temporary until all the models support this
-        if self.model_name in ["gpt-o1", 'gpt-o1-mini']:
+        if self.model_name in ["gpt-o1", 'gpt-o1-mini', 'gpt-o3', 'gpt-o3-mini']:
             self.root_message_role = "developer"
 
 


### PR DESCRIPTION
This pull request includes a small change to the `src/agent_c_core/src/agent_c/agents/gpt.py` file. The change adds support for the models `gpt-o3` and `gpt-o3-mini` to set the `root_message_role` to "developer".