### PR TITLE
Fix model names

### DIFF
--- a/src/agent_c_core/src/agent_c/agents/gpt.py
+++ b/src/agent_c_core/src/agent_c/agents/gpt.py
@@ -62,7 +62,7 @@ class GPTChatAgent(BaseAgent):
         self.supports_multimodal = True
 
         # Temporary until all the models support this
-        if self.model_name in ["gpt-o1", 'gpt-o1-mini', 'gpt-o3', 'gpt-o3-mini']:
+        if self.model_name in ["o1", 'o1-mini', 'o3', 'o3-mini']:
             self.root_message_role = "developer"
 
 


### PR DESCRIPTION
This pull request includes a change to the `__init__` method in the `src/agent_c_core/src/agent_c/agents/gpt.py` file. The change updates the model names in the conditional check for setting the `root_message_role` attribute.

* [`src/agent_c_core/src/agent_c/agents/gpt.py`](diffhunk://#diff-0b0b2a2155f664049de21c3c667705f1c11a5613fc2949087029caaff07e36cfL65-R65): Updated model names in the conditional check from "gpt-o1", "gpt-o1-mini", "gpt-o3", and "gpt-o3-mini" to "o1", "o1-mini", "o3", and "o3-mini".