### PR TITLE
Allow reasoning effort in completion options

### DIFF
--- a/src/agent_c_core/src/agent_c/agents/gpt.py
+++ b/src/agent_c_core/src/agent_c/agents/gpt.py
@@ -121,7 +121,11 @@ class GPTChatAgent(BaseAgent):
         messages = await self._construct_message_array(system_prompt=sys_prompt, **kwargs)
 
         functions: List[Dict[str, Any]] = self.tool_chest.active_open_ai_schemas
-        completion_opts = {"model": model_name, "temperature": temperature, "messages": messages, "stream": True}
+        if model_name in ["o1", 'o1-mini', 'o3', 'o3-mini']:
+            completion_opts = {"model": model_name, "messages": messages, "stream": True}
+        else:
+            completion_opts = {"model": model_name, "temperature": temperature, "messages": messages, "stream": True}
+
         if len(functions):
             completion_opts['tools'] = functions
 
@@ -134,6 +138,10 @@ class GPTChatAgent(BaseAgent):
         user = kwargs.get("user_name", None)
         if user is not None:
             completion_opts["user"] = user
+
+        reasoning_effort = kwargs.get("reasoning_effort", None)
+        if reasoning_effort is not None:
+            completion_opts["reasoning_effort"] = reasoning_effort
 
 
 


### PR DESCRIPTION
`reasoning_effort` should be a string in the for of  low, medium, high.  The default is medium.

This pull request includes updates to the `__interaction_setup` method in the `src/agent_c_core/src/agent_c/agents/gpt.py` file. The changes focus on refining the completion options based on specific conditions and adding a new parameter to the completion options.


Key changes include:

* Conditional model handling: Added specific model names to handle completion options differently when the model is one of ["o1", 'o1-mini', 'o3', 'o3-mini'] (`[src/agent_c_core/src/agent_c/agents/gpt.pyR124-R128](diffhunk://#diff-0b0b2a2155f664049de21c3c667705f1c11a5613fc2949087029caaff07e36cfR124-R128)`).
* New parameter addition: Included a new `reasoning_effort` parameter in the completion options if it is provided in the kwargs (`[src/agent_c_core/src/agent_c/agents/gpt.pyR142-R145](diffhunk://#diff-0b0b2a2155f664049de21c3c667705f1c11a5613fc2949087029caaff07e36cfR142-R145)`).