### PR TITLE
Refactor the ChatEvent into smaller focused events + a bonus

### DIFF
--- a/personas/toolman.md
+++ b/personas/toolman.md
@@ -1,4 +1,4 @@
-You are Time the Tool-Man, an expert Python developer that helps users with Python architecture, development and best practices who is also an expert at crafting tools for AI agents using a custom framework.  When asked to produce code you adhere to the following guidelines:
+You are Tim the Tool-Man, an expert Python developer that helps users with Python architecture, development and best practices who is also an expert at crafting tools for AI agents using a custom framework.  When asked to produce code you adhere to the following guidelines:
 
 -  Prefer the use of existing packages over writing new code.
 -  Use async methods where possible.
@@ -57,14 +57,13 @@ General guidelines:
                 - __init__.py
               - pyproject.toml
               - setup.py
-                
-                  
+
+ 
 - All paths are relative and sandboxed to the root of the workspace.
 - No path should START with a slash as that would mean it's not relative
 - You CAN list/read/write/append to files in this workspace via workspace-ls, workspace-read and workspace-write.  DO NOT tell the user to write files you can output to the workspace.
 - In order to access `src/agent_c_core/src/agent_c/agents/gpt.py` you would ask read `src/agent_c_core/src/agent_c/agents/gpt.py` from the `project` workspace using workspace-read.
 - When using the workspace tools to save code, you do not need to include the code in your output to the user, simply saving the file and describing the change is enough.
-
 
 ### Source conventions:
 - Source for tools belongs in the `my_agent_c/tools` folder

--- a/src/agent_c_core/src/agent_c/models/events/__init__.py
+++ b/src/agent_c_core/src/agent_c/models/events/__init__.py
@@ -1,0 +1,6 @@
+from agent_c.models.events.base import BaseEvent
+from agent_c.models.events.session_event import SessionEvent
+from agent_c.models.events.chat import CompletionEvent
+from agent_c.models.events.render_media import RenderMediaEvent
+from agent_c.models.events.tool_calls import ToolCallEvent, ToolCallDeltaEvent
+from agent_c.models.events.chat import InteractionEvent, MessageEvent, TextDeltaEvent, HistoryEvent, CompletionEvent

--- a/src/agent_c_core/src/agent_c/models/events/base.py
+++ b/src/agent_c_core/src/agent_c/models/events/base.py
@@ -1,0 +1,7 @@
+from pydantic import Field
+from typing import Optional, List, Union
+
+from agent_c.models.base import BaseModel
+
+class BaseEvent(BaseModel):
+    type: str = Field(..., description="The type of the event")

--- a/src/agent_c_core/src/agent_c/models/events/chat.py
+++ b/src/agent_c_core/src/agent_c/models/events/chat.py
@@ -1,0 +1,64 @@
+from pydantic import Field
+from typing import Optional, List
+from agent_c.models.events.session_event import SessionEvent
+
+class InteractionEvent(SessionEvent):
+    """
+    Sent to notify the UI that an interaction has been initiated or completed.
+    While an interaction is running, the UI should not allow input from the user.
+    """
+    def __init__(self, **data):
+        super().__init__(type = "interaction", **data)
+
+    started: bool = Field(..., description="If False, the interaction has been completed. And the UI should allow input from the use")
+    id: str = Field(..., description="The ID of the interaction")
+
+
+class CompletionEvent(SessionEvent):
+    """
+    Sent to notify the UI that the completion call
+    """
+    def __init__(self, **data):
+        super().__init__(type = "completion", **data)
+
+    running: bool = Field(..., description="If True, the completion will run immediately after the event goes out.")
+    completion_options: dict = Field(..., description="The completion options used, in vendor format")
+    stop_reason: Optional[str] = Field(None, description="The reason the completion was stopped")
+    input_tokens: Optional[int] = Field(None, description="The number of tokens in the input")
+    output_tokens: Optional[int] = Field(None, description="The number of tokens in the output")
+
+class MessageEvent(SessionEvent):
+    """
+    Sent to notify the UI to display an entire message.
+    """
+    def __init__(self, **data):
+        super().__init__(type = "message", **data)
+
+    content: str = Field(..., description="The content of the message")
+    format: str = Field("markdown", description="The format of the content, default is markdown")
+
+class TextDeltaEvent(SessionEvent):
+    """
+    Sent to notify the UI that a chunk of content text has been received.
+    - Clients should handle this event by appending the content to the current message,
+      for the role, within the current interaction.
+    - If there isn't a message for the role in the current interaction,
+      a new message should be created.
+    """
+    def __init__(self, **data):
+        super().__init__(type = "text_delta", **data)
+
+    content: str = Field(..., description="A chunk of content text.")
+    format: str = Field("markdown", description="The format of the content, default is markdown")
+
+
+
+
+class HistoryEvent(SessionEvent):
+    """
+    Sent to notify the UI that the message history has been updated.
+    """
+    def __init__(self, **data):
+        super().__init__(type = "history", **data)
+
+    messages: List[dict] = Field(..., description="The list of messages in the current chat history")

--- a/src/agent_c_core/src/agent_c/models/events/render_media.py
+++ b/src/agent_c_core/src/agent_c/models/events/render_media.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+from pydantic import ConfigDict, Field
+
+from agent_c.models.events.session_event import SessionEvent
+
+class RenderMediaEvent(SessionEvent):
+    """
+    Set when the agent or tool would like to render media to the user.
+    """
+    def __init__(self, **data):
+        super().__init__(type = "render_media", **data)
+
+    model_config = ConfigDict(populate_by_name=True)
+    content_type: str = Field(..., alias="content-type")
+    url: Optional[str] = None
+    name: Optional[str] = None
+    content: Optional[str] = None
+    content_bytes: Optional[bytes] = None

--- a/src/agent_c_core/src/agent_c/models/events/session_event.py
+++ b/src/agent_c_core/src/agent_c/models/events/session_event.py
@@ -1,0 +1,6 @@
+from pydantic import Field
+from agent_c.models.events.base import BaseEvent
+
+class SessionEvent(BaseEvent):
+    session_id: str = Field(..., description="The type of the event")
+    role: str = Field(..., description="The role that triggered this event event")

--- a/src/agent_c_core/src/agent_c/models/events/tool_calls.py
+++ b/src/agent_c_core/src/agent_c/models/events/tool_calls.py
@@ -1,0 +1,25 @@
+from pydantic import Field
+from typing import Optional, List
+from agent_c.models.events.session_event import SessionEvent
+
+class ToolCallEvent(SessionEvent):
+    """
+    Sent to notify the UI that tool use has been initiated or completed
+    """
+    active: bool = Field(..., description="If True, tools will be run immediately after the even goes out.")
+    vendor: str = Field(..., description="The completion API vendor.")
+    tool_calls: List[dict] = Field(..., description="A list of tool calls to be made. Currently in vendor format")
+    tool_results: Optional[List[dict]] = Field(None, description="A list of tool results. Currently in vendor format")
+
+    def __init__(self, **data):
+        super().__init__(type = "tool_call", **data)
+
+class ToolCallDeltaEvent(SessionEvent):
+    """
+    Sent to notify the UI that a chunk of tool_calls content has been received.
+    - Clients should handle this event by appending the content to the current message,
+    """
+    def __init__(self, **data):
+        super().__init__(type = "tool_select_delta", **data)
+
+    tool_calls: Optional[list[dict]] = Field(..., description="The current tool calls list.")

--- a/src/agent_c_reference_apps/src/agent_c_reference_apps/agent_c_cli.py
+++ b/src/agent_c_reference_apps/src/agent_c_reference_apps/agent_c_cli.py
@@ -253,11 +253,11 @@ class CLIChat:
 
         return logger
 
-    async def chat_callback(self, event: ChatEvent):
+    async def chat_callback(self, event):
         """
         Called by the ChatAgent and toolsets to notify us of events as they happen.
         """
-        if event.completed and event.role == 'assistant':
+        if event.type == 'history':
             self.current_chat_log = event.messages
 
         # Note we forward most events to the UI layer, if you want to see how to make a console UI feel free to dig in.

--- a/src/agent_c_tools/src/agent_c_tools/tools/mermaid_chart/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/mermaid_chart/tool.py
@@ -28,7 +28,7 @@ class MermaidChartTools(Toolset):
         graph_definition = kwargs.get('graph_definition')
         graph_name = kwargs.get('graph_name', "graph")
 
-        await self.chat_callback(content=f"Rendering graph:\n{graph_definition}")
+        await self._raise_text_delta_event(content=f"Rendering graph:\n{graph_definition}")
 
         graph: Graph = Graph(graph_name, graph_definition)
         rendered_graph: Mermaid = Mermaid(graph)
@@ -38,9 +38,9 @@ class MermaidChartTools(Toolset):
         cache_key = f"chart://{svg_name}"
         self.tool_cache.set(cache_key, rendered_graph.svg_response.text)
 
-        await self.chat_callback(content=f"\n\nRender complete, cached as: `{cache_key}`.")
-        await self.chat_callback(render_media={"content-type": "image/svg+xml", "url": svg_link,
-                                               "name": svg_name, "content": rendered_graph.svg_response.text})
+        await self._raise_text_delta_event(content=f"\n\nRender complete, cached as: `{cache_key}`.")
+        await self._raise_render_media(content_type="image/svg+xml", url=svg_link,
+                                       name=svg_name, content=rendered_graph.svg_response.text)
 
         return f"Render complete, cached as: `{cache_key}`. IF your client supports SVG, it will have been displayed by now."
 

--- a/src/agent_c_tools/src/agent_c_tools/tools/web/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/web/tool.py
@@ -84,7 +84,7 @@ class WebTools(Toolset):
         if url is None:
             return 'url is required'
 
-        await self.chat_callback(render_media={"content-type": "text/html", "url": url})
+        await self._raise_render_media(content_type="text/html", url=url)
 
         return f"Client displaying web page: {url}"
 


### PR DESCRIPTION
Big refactor of the event stream:

- ChatEvent has been broken into multiple events
- A new tool choice delta event that contains the tool_call list as it's being constructed by the model exists now.
- Token usage metrics are now reported at the end of each completion.
- Both GPT and Cluade completions emit consistent event flows.
- ALSO refactored the GPT Agent chat method to look more like the Claude one.
- `tool_choice` for GPT is now supported in the chat call.

This pull request includes several significant changes aimed at refactoring and enhancing the functionality of the `agent_c` module. The changes include updates to event handling, introduction of new methods for raising events, and modifications to the interaction setup process. Here are the most important changes:

### Refactoring and Enhancements:

* **Event Handling:**
  - Introduced new methods for raising different types of events such as `MessageEvent`, `ToolCallEvent`, `InteractionEvent`, `TextDeltaEvent`, `HistoryEvent`, and `CompletionEvent` in `src/agent_c_core/src/agent_c/agents/base.py`.
  - Replaced the `_callback` method with specific event-raising methods like `_raise_event`, `_raise_system_event`, `_raise_completion_start`, `_raise_completion_end`, `_raise_tool_call_start`, `_raise_tool_call_delta`, `_raise_tool_call_end`, `_raise_interaction_start`, `_raise_interaction_end`, `_raise_text_delta`, and `_raise_history_event` in `src/agent_c_core/src/agent_c/agents/base.py`.

* **Interaction Setup:**
  - Added new parameters `tool_choice` and `stream_options` to the `completion_opts` dictionary in the `__interaction_setup` method in `src/agent_c_core/src/agent_c/agents/gpt.py`. [[1]](diffhunk://#diff-0b0b2a2155f664049de21c3c667705f1c11a5613fc2949087029caaff07e36cfR100) [[2]](diffhunk://#diff-0b0b2a2155f664049de21c3c667705f1c11a5613fc2949087029caaff07e36cfR111-R120)
  - Updated the `chat` method to use the new event-raising methods and handle tool calls more effectively in `src/agent_c_core/src/agent_c/agents/gpt.py` and `src/agent_c_core/src/agent_c/agents/claude.py`. [[1]](diffhunk://#diff-0b0b2a2155f664049de21c3c667705f1c11a5613fc2949087029caaff07e36cfL187-R261) [[2]](diffhunk://#diff-d74867587f97368abcc0acaafc2f218509185212937c61d43c07a7fc5b791876L109-R171)

### Minor Changes:

* **Imports:**
  - Added imports for `copy`, `session`, `MnemonicSlugs`, and several event classes in `src/agent_c_core/src/agent_c/agents/base.py`.
  - Added import for `choice` in `src/agent_c_core/src/agent_c/agents/gpt.py`.

* **Documentation:**
  - Fixed a typo in the `personas/toolman.md` file, changing "Time the Tool-Man" to "Tim the Tool-Man".

These changes collectively improve the modularity and maintainability of the code, especially in terms of handling various events within the `agent_c` module.