### PR TITLE
Get the deference apps running in rocker

### DIFF
--- a/dockerfiles/Dockerfile.dev
+++ b/dockerfiles/Dockerfile.dev
@@ -1,10 +1,10 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bullseye
 
-# Set working directory
+# Set working directory and create required directories
 WORKDIR /app
-run mkdir -p /app/images
+RUN mkdir -p /app/images
 
-# Install system dependencies including Node.js for the React client
+# Install system dependencies using apt
 RUN apt-get update && apt-get install -y \
     curl \
     build-essential \
@@ -14,13 +14,14 @@ RUN apt-get update && apt-get install -y \
     python3-dev \
     libasound2-dev \
     ffmpeg \
-    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
-    && apt-get install -y nodejs \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    nodejs \
+    npm \
+    chromium \
+    chromium-driver \
+    cmake \
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
-
-# Copy the entire repository
+# Copy the entire repository into the image
 COPY . .
 
 # Upgrade pip
@@ -29,28 +30,36 @@ RUN pip install --no-cache-dir --upgrade pip
 # Install Python dependencies
 WORKDIR /app/src
 RUN pip install -e agent_c_core \
+    && pip install zep_cloud \
     && pip install -e agent_c_tools \
     && pip install -e my_agent_c \
     && pip install -e agent_c_reference_apps \
     && pip install -e agent_c_api_ui/agent_c_api
 
+
 # Install NPM dependencies for the React client
 WORKDIR /app/src/agent_c_api_ui/agent_c_react_client
 RUN npm install
 
-
+# Return to the app's root
 WORKDIR /app
 
-
+# Set environment variables
 ENV PYTHONPATH=/app
-ENV GRADIO_SERVER_NAME="0.0.0.0"
 ENV ENHANCED_DEBUG_INFO="True"
 ENV ENVIRONMENT="LOCAL_DEV"
 ENV CLI_CHAT_USER_ID="Taytay"
-ENV DALLE_IMAGE_SAVE_FOLDER="app/images"
+ENV DALLE_IMAGE_SAVE_FOLDER="/app/images"
 
+# Set the terminal type so the CLI UI works
+ENV TERM=xterm-256color
+
+# Set Selenium-related environment variables if needed
+ENV CHROME_BIN=/usr/bin/chromium
+ENV CHROMEDRIVER_PATH=/usr/bin/chromium-driver
+
+# Expose the Gradio server port
 EXPOSE 7860
 
 # Command to run when the container starts
-# Replace with your actual entry point command
-CMD ["python", "src/agent_c_reference_apps/src/agent_c_reference_apps/agent_c_cli.py"]
+CMD ["python", "src/agent_c_reference_apps/src/agent_c_reference_apps/agent_c_gradio.py"]

--- a/dockerfiles/README.md
+++ b/dockerfiles/README.md
@@ -1,0 +1,15 @@
+# Agent C Framework Dockerfiles 
+
+**All commands assume you're int the root folder of the project.**
+
+## Dev container:
+
+Build: `docker build -t agent_c_framework -f dockerfiles\Dockerfile.dev .`
+
+Run: `>docker run -it -p 7860:7860 --rm --env-file .env  agent_c_framework`
+
+When you see the message about going to http://0.0.0 open http://127.0.0.1:7860/ in your browser.
+
+- Note: you must have set up up your `.env` file
+- **Important**: If you already have a `.env` file remove quotes around strings in it before running thing.
+

--- a/example.env
+++ b/example.env
@@ -1,65 +1,65 @@
 # Open AI support
-OPENAI_API_KEY="FROM OPEN AI"
+OPENAI_API_KEY=FROM-OPEN-AI
 
 # Needed to use Azure OpenAI.  Note:  Do not add this if you don't have access to Azure OpenAI
 # as it will be used over the default OpenAI API if these keys are populated. (for now)
-AZURE_OPENAI_API_KEY="FROM AZURE"
-AZURE_OPENAI_ENDPOINT="https://YOURNAME.openai.azure.com/"
-AZURE_OPENAI_MODEL="YOURMODEL"
-AZURE_OPENAI_API_VERSION="2024-03-01-preview"
+AZURE_OPENAI_API_KEY=FROM-AZURE
+AZURE_OPENAI_ENDPOINT=https://YOURNAME.openai.azure.com/
+AZURE_OPENAI_MODEL=YOURMODEL
+AZURE_OPENAI_API_VERSION=2024-03-01-preview
 
 # Needed for Claude support
-#ANTHROPIC_API_KEY="FROM ANTHROPIC"
+#ANTHROPIC_API_KEY=FROM-ANTHROPIC
 
 
 # Chat Session Manager configuration
 
 # Zep API configuration
 # Zep Cloud users should set this
-ZEP_API_KEY"FROM ZEP"
+ZEP_API_KEY=FROM-ZEP
 
 # If you are using Zep CE locally use ZEP_CE_KEY and ZEP_URL
-ZEP_CE_KEY="FROM YOUR CONFIG"
-ZEP_URL="http://localhost:8001"
+ZEP_CE_KEY=FROM_YOUR_CONFIG
+ZEP_URL=http://localhost:8001
 
 # Basic Setup
 
 # You will want this set to LOCAL_DEV or DEVELOPMENT.
 # The default value is PRODUCTION to prevent anyone from ever
 # deploying to prod and having the agent think everyone was an admin.
-ENVIRONMENT="LOCAL_DEV"
+ENVIRONMENT=LOCAL_DEV
 
 # This is used as your used ID in Zep, the default is "default"
 # But this is hear to make sure you're paying attention. (Hi Hayden)
-CLI_CHAT_USER_ID="Taytay"
+CLI_CHAT_USER_ID=Taytay
 
 # Set this to a folder for the DALL-E-3 to save images to and it will save them there instead of generating a link
-#DALLE_IMAGE_SAVE_FOLDER="some/folder"
+DALLE_IMAGE_SAVE_FOLDER=some/folder
 
 # Advanced
-ROOT_MESSAGE_ROLE="developer"  # uncomment this if using a model other than GPT-4o that uses a different root message name from 'system'
+ROOT_MESSAGE_ROLE=developer  # uncomment this if using a model other than GPT-4o that uses a different root message name from 'system'
 
 # Output enhanced debug information
-ENHANCED_DEBUG_INFO="False"
+ENHANCED_DEBUG_INFO=False
 
 # API keys for various services consumed by tools.
 
 # SERPAPI_API_KEY for using google_search_results package
-# SERPAPI_API_KEY=''
+# SERPAPI_API_KEY=
 
 # SEC_API Key for accessing SEC filings via sec-api.io
-# SEC_API_KEY=''
+# SEC_API_KEY=
 
 # Tavili API Key for using the tavili package
-# TAVILI_API_KEY='tavilyapikey'
+# TAVILI_API_KEY=tavilyapikey
 
 # NewsAPI Key for using the https://newsapi.org
-#NEWSAPI_API_KEY='newsapikey'
+#NEWSAPI_API_KEY=newsapikey
 
 # For Salesforce Tool
 # to get token, click on your profile picture, settings, reset my security token, and click the reset security token button
 # new security token will be emailed to you
-SALESFORCE_USERID=''
-SALESFORCE_PASSWORD=''
-SALESFORCE_SECURITY_TOKEN=''
-SALESFORCE_DOMAIN=''
+SALESFORCE_USERID=
+SALESFORCE_PASSWORD=
+SALESFORCE_SECURITY_TOKEN=
+SALESFORCE_DOMAIN=

--- a/src/agent_c_reference_apps/src/agent_c_reference_apps/ui/gradio_ui.py
+++ b/src/agent_c_reference_apps/src/agent_c_reference_apps/ui/gradio_ui.py
@@ -656,12 +656,12 @@ class GradioChat:
             self.__init_ui()
 
             # Start the UI in the background
-            self.open_browser_after_delay("http://localhost:7860", 1)
-            self.audio_cues.play_sound('app_start')
+            #self.open_browser_after_delay("http://localhost:7860", 1)
+            #self.audio_cues.play_sound('app_start')
 
             self.ui.queue()
             self.ui.launch(
-                server_name='127.0.0.1',
+                server_name='0.0.0.0',
                 server_port=7860,
                 share=False,
                 inbrowser=False,  # Don't auto-open browser since we're using our own method
@@ -669,11 +669,11 @@ class GradioChat:
                 max_threads=40,  # Maximum number of threads for handling requests
                 show_error=True,
                 show_api=False,  # Disable API docs for faster loading
-                quiet=True,  # Reduce console output
+                quiet=False,  # Reduce console output
                 enable_monitoring=False,  # Disable monitoring for faster startup
                 height=500,
                 width="100%",
-                strict_cors=True
+                strict_cors=False
             )
         except Exception as e:
             self.logger.error(f"Error during startup: {str(e)}")


### PR DESCRIPTION
This pull request includes several updates to the development Dockerfile, environment configuration, and Gradio UI settings. The most important changes include updating the base image and dependencies in the Dockerfile, modifying environment variables in the example environment file, and adjusting the Gradio UI launch settings.

### Dockerfile Updates:
* Updated the base image to `python:3.12-slim-bullseye` and added new dependencies such as `chromium`, `chromium-driver`, and `cmake`. [[1]](diffhunk://#diff-3aa78c91b034247916310da7f568d894c859d54e0ba88442e062c3f11a8e62b9L1-R7) [[2]](diffhunk://#diff-3aa78c91b034247916310da7f568d894c859d54e0ba88442e062c3f11a8e62b9L17-R24)
* Added the installation of the `zep_cloud` Python package.
* Changed the entry point command to run the Gradio UI instead of the CLI.

### Environment Configuration:
* Removed quotes around string values in the `example.env` file to ensure proper environment variable parsing.

### Gradio UI Settings:
* Disabled the automatic opening of the browser and audio cues on startup, and adjusted server settings to listen on `0.0.0.0`.

### Documentation:
* Added a new section to `dockerfiles/README.md` with instructions on building and running the development container.