### PR TITLE
Adding personas to docker containers

### DIFF
--- a/dockerfiles/api.Dockerfile
+++ b/dockerfiles/api.Dockerfile
@@ -24,6 +24,9 @@ RUN apt-get update && apt-get install -y \
 # Copy source code first
 COPY src ./src
 
+# Copy in the personas - right now we mount in docker-compose
+COPY personas /app/personas
+
 # Copy agent_c_api pyproject.toml
 COPY src/agent_c_api_ui/agent_c_api/pyproject.toml ./pyproject.toml
 

--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -10,6 +10,7 @@ services:
     volumes:
       - ../src:/app/src  # For development hot-reloading
       - ../images:/app/images  # Mounted volume for saved images
+      - ../personas:/app/personas  # Mount personas directory - required for persona selection
     environment:
       - ENVIRONMENT=LOCAL_DEV
       - ENHANCED_DEBUG_INFO=True


### PR DESCRIPTION
This pull request includes changes to the Docker configuration files to ensure the personas directory is included and mounted properly. The most important changes are:

Dockerfile updates:
* [`dockerfiles/api.Dockerfile`](diffhunk://#diff-158a1dffd1eea9c866e9b45df11703f291fd1d05f7f35f12c527d3e1b05244afR27-R29): Added a step to copy the `personas` directory into the Docker image.

Docker Compose updates:
* [`dockerfiles/docker-compose.yml`](diffhunk://#diff-68e819f6c4b1c7db3b92c765cd799e8c5344688e73b6caa47fad6beadc3ef4bdR13): Added a volume mount for the `personas` directory to the `services` section to support persona selection.