### PR TITLE
Fix a compose issue with the frontend

### DIFF
--- a/dockerfiles/docker-compose.yml
+++ b/dockerfiles/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       dockerfile: dockerfiles/frontend.Dockerfile
     ports:
       - "5173:5173"
-    volumes:
-      - ../src/agent_c_api_ui/agent_c_react_client:/app  # For development hot-reloading
+    #volumes:
+    #  - ../src/agent_c_api_ui/agent_c_react_client:/app  # For development hot-reloading
     environment:
       - VITE_API_URL=http://localhost:8000/api/v1  # Use localhost for browser access
       - VITE_RAG_API_URL=http://localhost:8000/api/v1  # Use localhost for browser access

--- a/dockerfiles/frontend.Dockerfile
+++ b/dockerfiles/frontend.Dockerfile
@@ -1,33 +1,45 @@
 FROM node:20-slim
-
+ 
 # Set working directory
 WORKDIR /app
-
+ 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
     git \
-    && apt-get clean && rm -rf /var/lib/apt/lists/*
-
+    build-essential \
+    python3 \
+&& apt-get clean && rm -rf /var/lib/apt/lists/*
+ 
 # Copy package files
 COPY src/agent_c_api_ui/agent_c_react_client/package*.json ./
+ 
+# Workaround for the rollup dependency issue by creating a dummy module
+RUN mkdir -p node_modules/@rollup/rollup-linux-x64-gnu && \
+    echo "module.exports = {};" > node_modules/@rollup/rollup-linux-x64-gnu/index.js
+ 
+# Install global dependencies and configure npm as needed
 
-# Install dependencies
-RUN npm install
-
+RUN npm install -g node-gyp && \
+    npm config set legacy-peer-deps true
+ 
+# Install project dependencies
+RUN npm ci || (rm -rf node_modules && rm -f package-lock.json && npm install)
+ 
 # Copy the rest of the frontend code
 COPY src/agent_c_api_ui/agent_c_react_client/ ./
-
+ 
 # Build for production or use dev mode
 ARG NODE_ENV=development
 ENV NODE_ENV=${NODE_ENV}
-
+ 
 # Set environment variables
+
 # These can be overridden at runtime
 ENV VITE_API_URL=http://localhost:8000/api/v1
 ENV VITE_RAG_API_URL=http://localhost:8000/api/v1
-
+ 
 # Expose the Vite dev server port
 EXPOSE 5173
-
+ 
 # Command to run development server
 CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]


### PR DESCRIPTION
This pull request includes updates to the Docker configuration for the frontend service. The most significant changes involve commenting out the volume mounting for development hot-reloading, installing additional dependencies, and adding a workaround for a rollup dependency issue.

Updates to Docker configuration:

* [`dockerfiles/docker-compose.yml`](diffhunk://#diff-68e819f6c4b1c7db3b92c765cd799e8c5344688e73b6caa47fad6beadc3ef4bdL30-R31): Commented out the volume mounting for development hot-reloading.
* [`dockerfiles/frontend.Dockerfile`](diffhunk://#diff-78478502c1c5dbd2db98c021fc4129482653bb3bba089408f794c6a42d420d36R9-R26): Added `build-essential` and `python3` to the list of dependencies to be installed.
* [`dockerfiles/frontend.Dockerfile`](diffhunk://#diff-78478502c1c5dbd2db98c021fc4129482653bb3bba089408f794c6a42d420d36R9-R26): Added a workaround for a rollup dependency issue by creating a dummy module.
* [`dockerfiles/frontend.Dockerfile`](diffhunk://#diff-78478502c1c5dbd2db98c021fc4129482653bb3bba089408f794c6a42d420d36R9-R26): Added steps to install global dependencies and configure npm, including setting `legacy-peer-deps` to true.
* [`dockerfiles/frontend.Dockerfile`](diffhunk://#diff-78478502c1c5dbd2db98c021fc4129482653bb3bba089408f794c6a42d420d36R36): Added a blank line for better readability in the environment variables section.