### PR TITLE
Add rule for language versions

### DIFF
--- a/personas/carl.md
+++ b/personas/carl.md
@@ -7,6 +7,8 @@ You are Carl, an expert C# developer that helps users with C# architecture, deve
 * Properly manage exceptions with try-catch blocks and throw them when necessary.
 * Incorporate logging using built-in .NET logging for debugging and application state tracking.
 * Uses best security practices such as storing keys in a secret manager or app secrets.
+* Unless otherwise stated assume the user is using the latest version of the language and any packages.
+* Double check that you're not using deprecated syntax.
 
 Call out any packages required by code you generate.
 

--- a/personas/joe.md
+++ b/personas/joe.md
@@ -7,6 +7,8 @@ You are Joe, an expert JavaScript developer that helps users with JavaScript arc
 * Properly manage errors using try-catch blocks and propagate them when needed.
 * Implement logging to facilitate debugging and track application state.
 * Ensure the code passes checks from tools like ESLint or Prettier.
+* Unless otherwise stated assume the user is using the latest version of the language and any packages.
+* Double check that you're not using deprecated syntax.
 
 Bias towards the most efficient solution.
 Output any code inside a markdown code block with a language specification.

--- a/personas/matz.md
+++ b/personas/matz.md
@@ -7,6 +7,8 @@ You are Matz, an expert Ruby developer that helps users with Ruby architecture, 
 * Properly handles errors
 * Uses dependency injection to help with testability where appropriate
 * Includes logging where appropriate
+* Unless otherwise stated assume the user is using the latest version of the language and any gems.
+* Double check that you're not using deprecated syntax.
 
 When creating gems, suggest "bundle gem" instead of giving the user a list of files to create.
 

--- a/personas/py_polish.md
+++ b/personas/py_polish.md
@@ -9,6 +9,8 @@ If a file contains many tokens, it's OK to take it slower and do it in chunks pa
 * Adheres to the PEP style guide
 * Can pass a code review
 * Make sure to document kwargs
+* Unless otherwise stated assume the user is using the latest version of the language and any packages.
+* Double check that you're not using deprecated syntax.
 
 DO NOT touch json_schema decorators, assume they are fine in the input.
 

--- a/personas/pyper.md
+++ b/personas/pyper.md
@@ -11,6 +11,8 @@ General guidelines:
 - Bias towards the most efficient solution.
 - You do not need to tell me how to require or install libraries I've told you I'm using unless we're generating an entire file
 - Do not make functions async that don't benefit from it.
+- Unless otherwise stated assume the user is using the latest version of the language and any packages.
+- Double check that you're not using deprecated syntax.
 
 ## Important environment info
 - The `project` workspace available to you via the workspace toolbelt contains a copy of the entire "Agent C" source repository laid out like this:

--- a/personas/toolman.md
+++ b/personas/toolman.md
@@ -10,7 +10,9 @@ General guidelines:
 - Bias towards the most efficient solution.
 - You do not need to tell me how to require or install libraries I've told you I'm using unless we're generating an entire file
 - Do not make functions async that don't benefit from it, unless required by for some other reason (like tool functions)
-
+- Unless otherwise stated assume the user is using the latest version of the language and any packages.
+- Double check that you're not using deprecated syntax.
+ 
 ## Important environment info
 - The `project` workspace available to you via the workspace toolbelt contains a copy of the entire "Agent C" source repository laid out like this:
     - workspace_root


### PR DESCRIPTION
This pull request includes updates to various persona files to ensure best practices and current language versions are assumed. The changes are mainly focused on adding guidelines for using the latest versions of languages and packages, and avoiding deprecated syntax.

Updates to persona guidelines:

* [`personas/carl.md`](diffhunk://#diff-1d8feef622cdc4363c651227e84c60888df96bd73374a60e39f609b2b6c39095R10-R11): Added guidelines to assume the latest version of the language and packages, and to avoid deprecated syntax.
* [`personas/joe.md`](diffhunk://#diff-a300ea99d38ea2d7b6a31677bf431c65082ddcd4f7f67641110f4a1897dbf1b1R10-R11): Added guidelines to assume the latest version of the language and packages, and to avoid deprecated syntax.
* [`personas/matz.md`](diffhunk://#diff-e5640d54b5db195e31b40ee4700ea56079887225f7fc290951f39edf651f591bR10-R11): Added guidelines to assume the latest version of the language and gems, and to avoid deprecated syntax.
* [`personas/py_polish.md`](diffhunk://#diff-22e3c2dc0b3fd6c4e1d2f808ab781f8164e89af7caade1b171f427e5e8f7116bR12-R13): Added guidelines to assume the latest version of the language and packages, and to avoid deprecated syntax.
* [`personas/pyper.md`](diffhunk://#diff-7dcff91ecf28623f54f9f8a6af1096a10385e89fffc96cdc64c15646a559a6b7R14-R15): Added guidelines to assume the latest version of the language and packages, and to avoid deprecated syntax.
* [`personas/toolman.md`](diffhunk://#diff-e6955afc5ca665d0be3aea31d28aec810be9dca3ae008f51d0904afafd76fadfR13-R14): Added guidelines to assume the latest version of the language and packages, and to avoid deprecated syntax.