### PR TITLE
First stab at a workflow to build the docker images

### DIFF
--- a/.github/workflows/dev-docker-build-and-push.yml
+++ b/.github/workflows/dev-docker-build-and-push.yml
@@ -36,7 +36,8 @@ jobs:
         with:
           context: .
           file: ./dockerfiles/api.Dockerfile
-          push: true
+          # Only push when not a PR
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/agent_c_api_dev:latest
             ghcr.io/${{ github.repository_owner }}/agent_c_api_dev:build-${{ github.run_number }}
@@ -48,7 +49,8 @@ jobs:
         with:
           context: .
           file: ./dockerfiles/Dockerfile.dev
-          push: true
+          # Only push when not a PR
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/agent_c_framework_dev:latest
             ghcr.io/${{ github.repository_owner }}/agent_c_framework_dev:build-${{ github.run_number }}
@@ -60,7 +62,8 @@ jobs:
         with:
           context: .
           file: ./dockerfiles/frontend.Dockerfile
-          push: true
+          # Only push when not a PR
+          push: ${{ github.event_name != 'pull_request' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/agent_c_frontend_dev:latest
             ghcr.io/${{ github.repository_owner }}/agent_c_frontend_dev:build-${{ github.run_number }}

--- a/.github/workflows/dev-docker-build.yml
+++ b/.github/workflows/dev-docker-build.yml
@@ -1,0 +1,68 @@
+name: Build and Push Dev Docker Images
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up metadata
+        id: meta
+        run: |
+          echo "SHORT_SHA=$(echo ${GITHUB_SHA} | cut -c1-7)" >> $GITHUB_ENV
+          echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push API image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./dockerfiles/api.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/agent_c_api_dev:latest
+            ghcr.io/${{ github.repository_owner }}/agent_c_api_dev:build-${{ github.run_number }}
+            ghcr.io/${{ github.repository_owner }}/agent_c_api_dev:${{ env.SHORT_SHA }}
+            ghcr.io/${{ github.repository_owner }}/agent_c_api_dev:${{ env.DATE }}
+
+      - name: Build and push Framework image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./dockerfiles/Dockerfile.dev
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/agent_c_framework_dev:latest
+            ghcr.io/${{ github.repository_owner }}/agent_c_framework_dev:build-${{ github.run_number }}
+            ghcr.io/${{ github.repository_owner }}/agent_c_framework_dev:${{ env.SHORT_SHA }}
+            ghcr.io/${{ github.repository_owner }}/agent_c_framework_dev:${{ env.DATE }}
+
+      - name: Build and push Frontend image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./dockerfiles/frontend.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/agent_c_frontend_dev:latest
+            ghcr.io/${{ github.repository_owner }}/agent_c_frontend_dev:build-${{ github.run_number }}
+            ghcr.io/${{ github.repository_owner }}/agent_c_frontend_dev:${{ env.SHORT_SHA }}
+            ghcr.io/${{ github.repository_owner }}/agent_c_frontend_dev:${{ env.DATE }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to build and push development Docker images for the API, Framework, and Frontend components. The workflow is triggered by pushes and pull requests to the `main` branch, as well as manual dispatches.

Key changes include:

* Added a new GitHub Actions workflow file `.github/workflows/dev-docker-build.yml` to automate the building and pushing of Docker images for the development environment.
* Configured the workflow to trigger on push and pull request events to the `main` branch, and also allows manual triggering via `workflow_dispatch`.
* Included steps to log in to the GitHub Container Registry, build Docker images for API, Framework, and Frontend components, and push these images with multiple tags including `latest`, build number, short SHA, and date.