### PR TITLE
add workflow to publish python packages

### DIFF
--- a/.github/workflows/build-and-publish-python-packages.yml
+++ b/.github/workflows/build-and-publish-python-packages.yml
@@ -2,12 +2,8 @@ name: Build and Publish Python Packages
 
 on:
   push:
-    branches: [ main ]
-    # Only trigger if files in any of the package folders changed
-    paths:
-      - 'src/agent_c_core/**'
-      - 'src/agent_c_tools/**'
-      - 'src/agent_c_reference_apps/**'
+    tags:
+      - 'v*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-and-publish-python-packages.yml
+++ b/.github/workflows/build-and-publish-python-packages.yml
@@ -1,0 +1,124 @@
+name: Build and Publish Python Packages
+
+on:
+  push:
+    branches: [ main ]
+    # Only trigger if files in any of the package folders changed
+    paths:
+      - 'src/agent_c_core/**'
+      - 'src/agent_c_tools/**'
+      - 'src/agent_c_reference_apps/**'
+  workflow_dispatch:
+
+jobs:
+  build_agent_c_core:
+    name: Build and Publish agent_c_core
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check if agent_c_core changed
+        id: check
+        run: |
+          # Compare current commit with previous commit for changes in agent_c_core
+          if git diff --quiet HEAD^ HEAD -- src/agent_c_core; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+          echo "Change check result: $(cat $GITHUB_OUTPUT)"
+
+      - name: Bump version for agent_c_core
+        if: steps.check.outputs.changed == 'true'
+        run: python ci/bump_version.py src/agent_c_core/pyproject.toml ${{ github.run_number }}
+
+      - name: Build agent_c_core package
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          cd src/agent_c_core
+          python setup.py sdist bdist_wheel
+
+      - name: Publish agent_c_core package to GitHub Packages
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          twine upload --repository-url https://upload.github.com/ dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+  build_agent_c_tools:
+    name: Build and Publish agent_c_tools
+    runs-on: ubuntu-latest
+    needs: build_agent_c_core
+    outputs:
+      changed: ${{ steps.check.outputs.changed }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check if agent_c_tools changed
+        id: check
+        run: |
+          if git diff --quiet HEAD^ HEAD -- src/agent_c_tools; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+          echo "Change check result: $(cat $GITHUB_OUTPUT)"
+
+      - name: Bump version for agent_c_tools
+        if: steps.check.outputs.changed == 'true'
+        run: python ci/bump_version.py src/agent_c_tools/pyproject.toml ${{ github.run_number }}
+
+      - name: Build agent_c_tools package
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          cd src/agent_c_tools
+          python setup.py sdist bdist_wheel
+
+      - name: Publish agent_c_tools package to GitHub Packages
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          twine upload --repository-url https://upload.github.com/ dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+  build_agent_c_reference_apps:
+    name: Build and Publish agent_c_reference_apps
+    runs-on: ubuntu-latest
+    needs: build_agent_c_tools
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Check if agent_c_reference_apps changed
+        id: check
+        run: |
+          if git diff --quiet HEAD^ HEAD -- src/agent_c_reference_apps; then
+            echo "changed=false" >> $GITHUB_OUTPUT
+          else
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+          echo "Change check result: $(cat $GITHUB_OUTPUT)"
+
+      - name: Bump version for agent_c_reference_apps
+        if: steps.check.outputs.changed == 'true'
+        run: python ci/bump_version.py src/agent_c_reference_apps/pyproject.toml ${{ github.run_number }}
+
+      - name: Build agent_c_reference_apps package
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          cd src/agent_c_reference_apps
+          python setup.py sdist bdist_wheel
+
+      - name: Publish agent_c_reference_apps package to GitHub Packages
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          twine upload --repository-url https://upload.github.com/ dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-publish-python-packages.yml
+++ b/.github/workflows/build-and-publish-python-packages.yml
@@ -2,8 +2,12 @@ name: Build and Publish Python Packages
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [ main ]
+    # Only trigger if files in any of the package folders changed
+    paths:
+      - 'src/agent_c_core/**'
+      - 'src/agent_c_tools/**'
+      - 'src/agent_c_reference_apps/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build-and-publish-python-packages.yml
+++ b/.github/workflows/build-and-publish-python-packages.yml
@@ -1,21 +1,16 @@
 name: Build and Publish Python Packages
 
 on:
-  push:
+  pull_request:
     branches: [ main ]
-    # Only trigger if files in any of the package folders changed
-    paths:
-      - 'src/agent_c_core/**'
-      - 'src/agent_c_tools/**'
-      - 'src/agent_c_reference_apps/**'
+    types: [ closed ]
   workflow_dispatch:
 
 jobs:
   build_agent_c_core:
     name: Build and Publish agent_c_core
     runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.check.outputs.changed }}
+    if: ${{ github.event.pull_request.merged == true }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -53,8 +48,7 @@ jobs:
     name: Build and Publish agent_c_tools
     runs-on: ubuntu-latest
     needs: build_agent_c_core
-    outputs:
-      changed: ${{ steps.check.outputs.changed }}
+    if: ${{ github.event.pull_request.merged == true }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -91,6 +85,7 @@ jobs:
     name: Build and Publish agent_c_reference_apps
     runs-on: ubuntu-latest
     needs: build_agent_c_tools
+    if: ${{ github.event.pull_request.merged == true }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/main-docker-build-and-push.yml
+++ b/.github/workflows/main-docker-build-and-push.yml
@@ -1,10 +1,9 @@
 name: Build and Push Dev Docker Images
 
 on:
-  push:
+  pull_request:
     branches: [ main ]
-    paths:
-      - 'src/agent_c_*/**'
+    types: [ closed ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main-docker-build-and-push.yml
+++ b/.github/workflows/main-docker-build-and-push.yml
@@ -3,8 +3,8 @@ name: Build and Push Dev Docker Images
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    paths:
+      - 'src/agent_c_*/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tagged-docker-build-and-push.yml
+++ b/.github/workflows/tagged-docker-build-and-push.yml
@@ -2,11 +2,9 @@ name: Build and Push Dev Docker Images
 
 on:
   push:
-    branches: [ main ]
-    tags:
-      - 'v*'
-    paths:
-      - 'src/agent_c_*/**'
+    push:
+      tags:
+        - 'v*'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/tagged-docker-build-and-push.yml
+++ b/.github/workflows/tagged-docker-build-and-push.yml
@@ -1,0 +1,73 @@
+name: Build and Push Dev Docker Images
+
+on:
+  push:
+    branches: [ main ]
+    tags:
+      - 'v*'
+    paths:
+      - 'src/agent_c_*/**'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up metadata
+        id: meta
+        run: |
+          echo "SHORT_SHA=$(echo ${GITHUB_SHA} | cut -c1-7)" >> $GITHUB_ENV
+          echo "DATE=$(date +'%Y%m%d')" >> $GITHUB_ENV
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push API image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./dockerfiles/api.Dockerfile
+          # Only push when not a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/agent_c_api_dev:latest
+            ghcr.io/${{ github.repository_owner }}/agent_c_api_dev:build-${{ github.run_number }}
+            ghcr.io/${{ github.repository_owner }}/agent_c_api_dev:${{ env.SHORT_SHA }}
+            ghcr.io/${{ github.repository_owner }}/agent_c_api_dev:${{ env.DATE }}
+
+      - name: Build and push Framework image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./dockerfiles/Dockerfile.dev
+          # Only push when not a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/agent_c_framework_dev:latest
+            ghcr.io/${{ github.repository_owner }}/agent_c_framework_dev:build-${{ github.run_number }}
+            ghcr.io/${{ github.repository_owner }}/agent_c_framework_dev:${{ env.SHORT_SHA }}
+            ghcr.io/${{ github.repository_owner }}/agent_c_framework_dev:${{ env.DATE }}
+
+      - name: Build and push Frontend image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          file: ./dockerfiles/frontend.Dockerfile
+          # Only push when not a PR
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/agent_c_frontend_dev:latest
+            ghcr.io/${{ github.repository_owner }}/agent_c_frontend_dev:build-${{ github.run_number }}
+            ghcr.io/${{ github.repository_owner }}/agent_c_frontend_dev:${{ env.SHORT_SHA }}
+            ghcr.io/${{ github.repository_owner }}/agent_c_frontend_dev:${{ env.DATE }}

--- a/ci/bump_version.py
+++ b/ci/bump_version.py
@@ -1,0 +1,40 @@
+import sys
+import toml
+
+
+def bump_version(file_path, build_number):
+    # Load the TOML file
+    data = toml.load(file_path)
+
+    # Attempt to retrieve the current version from common sections.
+    # Adjust the keys below based on your project's configuration.
+    version = None
+    if "tool" in data and "poetry" in data["tool"]:
+        version = data["tool"]["poetry"].get("version")
+    if not version and "project" in data:
+        version = data["project"].get("version")
+    if not version:
+        print("Version not found in the file.")
+        sys.exit(1)
+
+    # Append the build number (you could choose a different format)
+    new_version = f"{version}+{build_number}"
+
+    # Update version in the sections if present.
+    if "tool" in data and "poetry" in data["tool"] and "version" in data["tool"]["poetry"]:
+        data["tool"]["poetry"]["version"] = new_version
+    if "project" in data and "version" in data["project"]:
+        data["project"]["version"] = new_version
+
+    # Write changes back to the file.
+    with open(file_path, "w") as f:
+        toml.dump(data, f)
+
+    print(f"Updated version to {new_version} in {file_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 3:
+        print("Usage: bump_version.py <path_to_pyproject.toml> <build_number>")
+        sys.exit(1)
+    bump_version(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to automate the build and publish process for Python packages and includes a script to bump the version of the packages. The most important changes include the addition of the workflow configuration and the version bumping script.

Workflow automation:

* [`.github/workflows/build-and-publish-python-packages.yml`](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR1-R124): Added a new GitHub Actions workflow to build and publish Python packages for `agent_c_core`, `agent_c_tools`, and `agent_c_reference_apps`. The workflow triggers on pushes to the main branch and checks for changes in specific directories before proceeding with the build and publish steps.

Version bumping script:

* [`ci/bump_version.py`](diffhunk://#diff-21000c0394ee4f1e8e194349e583be7eb30684da777fa041c1241b549e2448dcR1-R40): Added a new script to bump the version of the Python packages by appending the build number to the current version found in the `pyproject.toml` file. The script updates the version in the appropriate sections and writes the changes back to the file.