### PR TITLE
fix python runner?

### DIFF
--- a/.github/workflows/build-and-publish-python-packages.yml
+++ b/.github/workflows/build-and-publish-python-packages.yml
@@ -53,6 +53,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Upgrade pip and install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine toml
+
       - name: Check if agent_c_tools changed
         id: check
         run: |


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for building and publishing Python packages. The most important change is the addition of steps to set up Python and upgrade pip and install necessary build tools.

Workflow updates:

* [`.github/workflows/build-and-publish-python-packages.yml`](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR56-R65): Added a step to set up Python using `actions/setup-python@v4` with Python version 3.12.
* [`.github/workflows/build-and-publish-python-packages.yml`](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR56-R65): Added a step to upgrade pip and install build tools including `build`, `twine`, and `toml`.