### PR TITLE
Make sure each package gets toml installed and the right python version

### DIFF
--- a/.github/workflows/build-and-publish-python-packages.yml
+++ b/.github/workflows/build-and-publish-python-packages.yml
@@ -15,6 +15,16 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Upgrade pip and install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine toml
+
       - name: Check if agent_c_core changed
         id: check
         run: |
@@ -99,6 +109,16 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+
+      - name: Upgrade pip and install build tools
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine toml
 
       - name: Check if agent_c_reference_apps changed
         id: check


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for building and publishing Python packages. The changes focus on setting up the Python environment and upgrading pip and build tools.

Key changes:

* [`.github/workflows/build-and-publish-python-packages.yml`](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR18-R27): Added steps to set up Python 3.12 and upgrade pip and install build tools in two different job sections. [[1]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR18-R27) [[2]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR113-R122)