### PR TITLE
Add setuprools to the package runner

### DIFF
--- a/.github/workflows/build-and-publish-python-packages.yml
+++ b/.github/workflows/build-and-publish-python-packages.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine toml
+          pip install build twine toml setuptools
 
       - name: Check if agent_c_reference_apps changed
         id: check


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build-and-publish-python-packages.yml` file. The change updates the list of build tools to include `setuptools` during the pip installation process.

* [`.github/workflows/build-and-publish-python-packages.yml`](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL121-R121): Added `setuptools` to the list of packages installed by pip.