### PR TITLE
Add setuprools to the package runner

### DIFF
--- a/.github/workflows/build-and-publish-python-packages.yml
+++ b/.github/workflows/build-and-publish-python-packages.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine toml
+          pip install build twine toml setuptools
 
       - name: Check if agent_c_core changed
         id: check
@@ -71,7 +71,7 @@ jobs:
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine toml
+          pip install build twine toml setuptools
 
       - name: Check if agent_c_tools changed
         id: check


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/build-and-publish-python-packages.yml` file to enhance the build process for Python packages. The most important changes involve the addition of `setuptools` to the list of installed build tools.

Enhancements to build process:

* [`.github/workflows/build-and-publish-python-packages.yml`](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL26-R26): Added `setuptools` to the list of packages installed during the build process to ensure all necessary build tools are available. [[1]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL26-R26) [[2]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL74-R74)