### PR TITLE
Make sure the package runner CDs into the right folder

### DIFF
--- a/.github/workflows/build-and-publish-python-packages.yml
+++ b/.github/workflows/build-and-publish-python-packages.yml
@@ -49,6 +49,7 @@ jobs:
       - name: Publish agent_c_core package to GitHub Packages
         if: steps.check.outputs.changed == 'true'
         run: |
+          cd src/agent_c_core
           twine upload --repository-url https://upload.github.com/ dist/*
         env:
           TWINE_USERNAME: __token__
@@ -96,6 +97,7 @@ jobs:
       - name: Publish agent_c_tools package to GitHub Packages
         if: steps.check.outputs.changed == 'true'
         run: |
+          cd src/agent_c_tools
           twine upload --repository-url https://upload.github.com/ dist/*
         env:
           TWINE_USERNAME: __token__
@@ -143,6 +145,7 @@ jobs:
       - name: Publish agent_c_reference_apps package to GitHub Packages
         if: steps.check.outputs.changed == 'true'
         run: |
+          cd src/agent_c_reference_apps
           twine upload --repository-url https://upload.github.com/ dist/*
         env:
           TWINE_USERNAME: __token__


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/build-and-publish-python-packages.yml` file to ensure that the correct directories are targeted when publishing packages to GitHub Packages.

Improvements to the publishing process:

* [`.github/workflows/build-and-publish-python-packages.yml`](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR52): Added `cd` commands to navigate to the appropriate directories before running the `twine upload` command for the `agent_c_core`, `agent_c_tools`, and `agent_c_reference_apps` packages. [[1]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR52) [[2]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR100) [[3]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR148)