### PR TITLE
Packages

### DIFF
--- a/.github/workflows/build-and-publish-python-packages.yml
+++ b/.github/workflows/build-and-publish-python-packages.yml
@@ -11,6 +11,9 @@ jobs:
     name: Build and Publish agent_c_core
     runs-on: ubuntu-latest
     if: ${{ github.event.pull_request.merged == true }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -23,7 +26,7 @@ jobs:
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine toml setuptools
+          pip install build setuptools wheel
 
       - name: Check if agent_c_core changed
         id: check
@@ -44,22 +47,24 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         run: |
           cd src/agent_c_core
-          python setup.py sdist bdist_wheel
+          python -m build
 
       - name: Publish agent_c_core package to GitHub Packages
         if: steps.check.outputs.changed == 'true'
-        run: |
-          cd src/agent_c_core
-          twine upload --repository-url https://upload.github.com/ dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: src/agent_c_core/dist/
+          repository-url: https://maven.pkg.github.com/${{ github.repository }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
   build_agent_c_tools:
     name: Build and Publish agent_c_tools
     runs-on: ubuntu-latest
     needs: build_agent_c_core
     if: ${{ github.event.pull_request.merged == true }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -72,7 +77,7 @@ jobs:
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine toml setuptools
+          pip install build setuptools wheel
 
       - name: Check if agent_c_tools changed
         id: check
@@ -92,22 +97,24 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         run: |
           cd src/agent_c_tools
-          python setup.py sdist bdist_wheel
+          python -m build
 
       - name: Publish agent_c_tools package to GitHub Packages
         if: steps.check.outputs.changed == 'true'
-        run: |
-          cd src/agent_c_tools
-          twine upload --repository-url https://upload.github.com/ dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: src/agent_c_tools/dist/
+          repository-url: https://maven.pkg.github.com/${{ github.repository }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
   build_agent_c_reference_apps:
     name: Build and Publish agent_c_reference_apps
     runs-on: ubuntu-latest
     needs: build_agent_c_tools
     if: ${{ github.event.pull_request.merged == true }}
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -120,7 +127,7 @@ jobs:
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build twine toml setuptools
+          pip install build setuptools wheel
 
       - name: Check if agent_c_reference_apps changed
         id: check
@@ -140,13 +147,12 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         run: |
           cd src/agent_c_reference_apps
-          python setup.py sdist bdist_wheel
+          python -m build
 
       - name: Publish agent_c_reference_apps package to GitHub Packages
         if: steps.check.outputs.changed == 'true'
-        run: |
-          cd src/agent_c_reference_apps
-          twine upload --repository-url https://upload.github.com/ dist/*
-        env:
-          TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: src/agent_c_reference_apps/dist/
+          repository-url: https://maven.pkg.github.com/${{ github.repository }}
+          password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-and-publish-python-packages.yml
+++ b/.github/workflows/build-and-publish-python-packages.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build setuptools wheel
+          pip install build setuptools wheel toml
 
       - name: Check if agent_c_core changed
         id: check
@@ -77,7 +77,7 @@ jobs:
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build setuptools wheel
+          pip install build setuptools wheel toml
 
       - name: Check if agent_c_tools changed
         id: check
@@ -127,7 +127,7 @@ jobs:
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build setuptools wheel
+          pip install build setuptools wheel toml
 
       - name: Check if agent_c_reference_apps changed
         id: check


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow for building and publishing Python packages. The changes focus on improving security permissions, updating dependencies, and simplifying the build and publish steps.

Improvements to security permissions:

* Added `contents: read` and `packages: write` permissions to the `build_agent_c_core`, `build_agent_c_tools`, and `build_agent_c_reference_apps` jobs. [[1]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR14-R16) [[2]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL75-R80) [[3]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL123-R130)

Dependency updates:

* Replaced `twine` with `wheel` in the `pip install` command for all jobs. [[1]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL26-R29) [[2]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL75-R80) [[3]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL123-R130)

Simplification of build and publish steps:

* Replaced `python setup.py sdist bdist_wheel` with `python -m build` for all jobs. [[1]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL47-R67) [[2]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL95-R117) [[3]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL143-R158)
* Replaced manual `twine upload` commands with the `pypa/gh-action-pypi-publish` GitHub Action for all jobs. [[1]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL47-R67) [[2]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL95-R117) [[3]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL143-R158)