### PR TITLE
package workflow shot in the dark #399

### DIFF
--- a/.github/workflows/build-and-publish-python-packages.yml
+++ b/.github/workflows/build-and-publish-python-packages.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build setuptools wheel toml
+          pip install build setuptools wheel
 
       - name: Check if agent_c_core changed
         id: check
@@ -43,6 +43,16 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         run: python ci/bump_version.py src/agent_c_core/pyproject.toml ${{ github.run_number }}
 
+      - name: Setup GitHub Packages environment
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          echo "[distutils]" >> ~/.pypirc
+          echo "index-servers = github" >> ~/.pypirc
+          echo "[github]" >> ~/.pypirc
+          echo "repository = https://github.com/centricconsulting/agent_c_framework" >> ~/.pypirc
+          echo "username = ${{ github.actor }}" >> ~/.pypirc
+          echo "password = ${{ secrets.GITHUB_TOKEN }}" >> ~/.pypirc
+
       - name: Build agent_c_core package
         if: steps.check.outputs.changed == 'true'
         run: |
@@ -51,11 +61,13 @@ jobs:
 
       - name: Publish agent_c_core package to GitHub Packages
         if: steps.check.outputs.changed == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: src/agent_c_core/dist/
-          repository-url: https://maven.pkg.github.com/${{ github.repository }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd src/agent_c_core
+          pip install -U pip twine toml
+          python -m twine upload --repository github dist/*
+        env:
+          TWINE_USERNAME: ${{ github.actor }}
+          TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
   build_agent_c_tools:
     name: Build and Publish agent_c_tools
@@ -77,7 +89,7 @@ jobs:
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build setuptools wheel toml
+          pip install build setuptools wheel
 
       - name: Check if agent_c_tools changed
         id: check
@@ -93,6 +105,16 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         run: python ci/bump_version.py src/agent_c_tools/pyproject.toml ${{ github.run_number }}
 
+      - name: Setup GitHub Packages environment
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          echo "[distutils]" >> ~/.pypirc
+          echo "index-servers = github" >> ~/.pypirc
+          echo "[github]" >> ~/.pypirc
+          echo "repository = https://github.com/centricconsulting/agent_c_framework" >> ~/.pypirc
+          echo "username = ${{ github.actor }}" >> ~/.pypirc
+          echo "password = ${{ secrets.GITHUB_TOKEN }}" >> ~/.pypirc
+
       - name: Build agent_c_tools package
         if: steps.check.outputs.changed == 'true'
         run: |
@@ -101,11 +123,13 @@ jobs:
 
       - name: Publish agent_c_tools package to GitHub Packages
         if: steps.check.outputs.changed == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: src/agent_c_tools/dist/
-          repository-url: https://maven.pkg.github.com/${{ github.repository }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd src/agent_c_tools
+          pip install -U pip twine toml
+          python -m twine upload --repository github dist/*
+        env:
+          TWINE_USERNAME: ${{ github.actor }}
+          TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
 
   build_agent_c_reference_apps:
     name: Build and Publish agent_c_reference_apps
@@ -127,7 +151,7 @@ jobs:
       - name: Upgrade pip and install build tools
         run: |
           python -m pip install --upgrade pip
-          pip install build setuptools wheel toml
+          pip install build setuptools wheel
 
       - name: Check if agent_c_reference_apps changed
         id: check
@@ -143,6 +167,16 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         run: python ci/bump_version.py src/agent_c_reference_apps/pyproject.toml ${{ github.run_number }}
 
+      - name: Setup GitHub Packages environment
+        if: steps.check.outputs.changed == 'true'
+        run: |
+          echo "[distutils]" >> ~/.pypirc
+          echo "index-servers = github" >> ~/.pypirc
+          echo "[github]" >> ~/.pypirc
+          echo "repository = https://github.com/centricconsulting/agent_c_framework" >> ~/.pypirc
+          echo "username = ${{ github.actor }}" >> ~/.pypirc
+          echo "password = ${{ secrets.GITHUB_TOKEN }}" >> ~/.pypirc
+
       - name: Build agent_c_reference_apps package
         if: steps.check.outputs.changed == 'true'
         run: |
@@ -151,8 +185,10 @@ jobs:
 
       - name: Publish agent_c_reference_apps package to GitHub Packages
         if: steps.check.outputs.changed == 'true'
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          packages-dir: src/agent_c_reference_apps/dist/
-          repository-url: https://maven.pkg.github.com/${{ github.repository }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd src/agent_c_reference_apps
+          pip install -U pip twine toml
+          python -m twine upload --repository github dist/*
+        env:
+          TWINE_USERNAME: ${{ github.actor }}
+          TWINE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to the build and publish workflow for Python packages in the `.github/workflows/build-and-publish-python-packages.yml` file. The changes focus on removing redundant dependencies, setting up the GitHub Packages environment, and modifying the publishing process.

Improvements to dependency management:

* Removed `toml` from the list of dependencies installed during the upgrade step. [[1]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL29-R29) [[2]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL80-R92) [[3]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL130-R154)

Setup of GitHub Packages environment:

* Added a step to set up the GitHub Packages environment before building the packages, ensuring the necessary configuration is in place. [[1]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR46-R55) [[2]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR108-R117) [[3]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bR170-R179)

Changes to the publishing process:

* Replaced the `pypa/gh-action-pypi-publish` action with a custom script to upload the packages using `twine`, providing more control over the publishing process. [[1]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL54-R70) [[2]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL104-R132) [[3]](diffhunk://#diff-1ba28fd6c8983f7f2a87b2828b0710209a102cbfea2a8b780ac229faf65e567bL154-R194)