### PR TITLE
Test the new pipeline

### DIFF
--- a/dockerfiles/base/python/Dockerfile
+++ b/dockerfiles/base/python/Dockerfile
@@ -14,7 +14,6 @@ RUN apt-get update && apt-get install -y \
     curl \
     build-essential \
     git \
-    vim \
     portaudio19-dev \
     python3-dev \
     libasound2-dev \


### PR DESCRIPTION
This pull request includes a small change to the `dockerfiles/base/python/Dockerfile` file. The change removes the installation of `vim` from the list of packages to be installed.

* [`dockerfiles/base/python/Dockerfile`](diffhunk://#diff-e9711fa761dcb0a039847fa35d5b29468378cf5037f8206b87536429775264bfL17): Removed `vim` from the list of packages to be installed.