### PR TITLE
Fix the workflow to acutally publish the containers

### DIFF
--- a/.github/workflows/main-docker-build-and-push.yml
+++ b/.github/workflows/main-docker-build-and-push.yml
@@ -3,7 +3,12 @@ name: Build and Push Dev Docker Images
 on:
   pull_request:
     branches: [ main ]
+    types: [ opened, synchronize, reopened ]
+  pull_request_target:
+    branches: [ main ]
     types: [ closed ]
+  push:
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
@@ -62,8 +67,8 @@ jobs:
         with:
           context: ./dockerfiles/base/python
           file: ./dockerfiles/base/python/Dockerfile
-          # Only push when not a PR
-          push: true
+          # Push on PR close, push to main, or manual dispatch
+          push: ${{ github.event_name == 'pull_request_target' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/agent_c_python_base:latest
             ghcr.io/${{ github.repository_owner }}/agent_c_python_base:build-${{ github.run_number }}
@@ -71,7 +76,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/agent_c_python_base:${{ env.DATE }}
 
       - name: Verify base image push
-        if: needs.check-changes.outputs.base_changed == 'true'
+        if: (needs.check-changes.outputs.base_changed == 'true') && (github.event_name == 'pull_request_target' || github.event_name == 'push' || github.event_name == 'workflow_dispatch')
         run: |
           echo "Verifying base image was published"
           docker pull ghcr.io/${{ github.repository_owner }}/agent_c_python_base:${{ env.SHORT_SHA }} || echo "Failed to pull image - may not be available immediately"
@@ -81,8 +86,8 @@ jobs:
         with:
           context: .
           file: ./dockerfiles/api.Dockerfile
-          # Only push when not a PR
-          push: ${{ github.event_name != 'pull_request' }}
+          # Push on PR close, push to main, or manual dispatch
+          push: ${{ github.event_name == 'pull_request_target' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/agent_c_api_dev:latest
             ghcr.io/${{ github.repository_owner }}/agent_c_api_dev:build-${{ github.run_number }}
@@ -94,8 +99,8 @@ jobs:
         with:
           context: .
           file: ./dockerfiles/frontend.Dockerfile
-          # Only push when not a PR
-          push: ${{ github.event_name != 'pull_request' }}
+          # Push on PR close, push to main, or manual dispatch
+          push: ${{ github.event_name == 'pull_request_target' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
           tags: |
             ghcr.io/${{ github.repository_owner }}/agent_c_frontend_dev:latest
             ghcr.io/${{ github.repository_owner }}/agent_c_frontend_dev:build-${{ github.run_number }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and pushing Docker images. The main changes involve modifying the conditions under which Docker images are pushed to the repository. These changes ensure that images are pushed on pull request close, push to the main branch, or manual dispatch.

Key changes include:

* Updated the `pull_request` and `push` triggers to include branches and event types for building and pushing Docker images. (`.github/workflows/main-docker-build-and-push.yml`)
* Modified the `push` condition in the `jobs:` section to push images on PR close, push to main, or manual dispatch for the base Python image. (`.github/workflows/main-docker-build-and-push.yml`)
* Updated the `push` condition for the API Dockerfile to push images on PR close, push to main, or manual dispatch. (`.github/workflows/main-docker-build-and-push.yml`)
* Adjusted the `push` condition for the frontend Dockerfile to push images on PR close, push to main, or manual dispatch. (`.github/workflows/main-docker-build-and-push.yml`)