### PR TITLE
Found edge case that needed fixed.

### DIFF
--- a/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_manager.py
+++ b/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_manager.py
@@ -75,8 +75,8 @@ class UItoAgentBridgeManager:
         # If updating existing session, use that ID, otherwise generate new one - this will transfer chat history
         ui_session_id = existing_ui_session_id if existing_ui_session_id else str(uuid.uuid4())
 
-        # Extract custom_persona_text explicitly to avoid it being lost or overridden
-        custom_persona_text = kwargs.pop('custom_persona_text', None)
+        # Extract custom_prompt explicitly to avoid it being lost or overridden
+        custom_prompt = kwargs.pop('custom_prompt', None)
 
         # Create lock if it doesn't exist
         if ui_session_id not in self._locks:
@@ -87,12 +87,12 @@ class UItoAgentBridgeManager:
             existing_session = self.ui_sessions.get(ui_session_id, {})
             existing_agent: BaseAgent | None = existing_session.get("agent", None)
 
-            # IMPORTANT FIX: If we're changing models and no custom_persona_text was passed with the model change,
+            # IMPORTANT FIX: If we're changing models and no custom_prompt was passed with the model change,
             # but the existing agent has one, we need to preserve it
-            if existing_agent and custom_persona_text is None and existing_agent.custom_persona_text:
-                # this should work even if custom_persona_text==existing_agent.custom_persona_text - will be same value
-                custom_persona_text = existing_agent.custom_persona_text
-                self.logger.info(f"Preserving existing custom_persona_text: {custom_persona_text[:10]}...")
+            if existing_agent and custom_prompt is None and existing_agent.custom_prompt:
+                # this should work even if custom_prompt==existing_agent.custom_prompt - will be same value
+                custom_prompt = existing_agent.custom_prompt
+                self.logger.info(f"Preserving existing custom_prompt: {custom_prompt[:10]}...")
 
             # Initialize agent bridge for this session - this creates a session manager that will persist history
             agent = AgentBridge(
@@ -102,7 +102,7 @@ class UItoAgentBridgeManager:
                 additional_tools=additional_tools or [],
                 persona_name=persona_name,
                 agent_name=f"Agent_{ui_session_id}",
-                custom_prompt=custom_persona_text,
+                custom_prompt=custom_prompt,
                 **kwargs
             )
 

--- a/src/agent_c_api_ui/agent_c_api/src/agent_c_api/tests/persona_test.py
+++ b/src/agent_c_api_ui/agent_c_api/src/agent_c_api/tests/persona_test.py
@@ -37,7 +37,7 @@ class TestCustomPersonaPersistence(unittest.TestCase):
             backend="openai",
             model_name="gpt-4o",
             persona_name="default",
-            custom_persona_text=self.custom_prompt
+            custom_prompt=self.custom_prompt
         )
 
         # Mock private methods correctly - using the name-mangled version
@@ -46,13 +46,13 @@ class TestCustomPersonaPersistence(unittest.TestCase):
                               new_callable=AsyncMock) as mock_init_tools:
                 with patch.object(AgentBridge, '_ReactJSAgent__init_agent', new_callable=AsyncMock) as mock_init_agent:
                     # Check initial state
-                    self.assertEqual(agent.custom_persona_text, self.custom_prompt)
+                    self.assertEqual(agent.custom_prompt, self.custom_prompt)
 
                     # Run initialization with mocked dependencies
                     self.loop.run_until_complete(agent.initialize())
 
                     # Verify custom prompt still exists after initialization
-                    self.assertEqual(agent.custom_persona_text, self.custom_prompt)
+                    self.assertEqual(agent.custom_prompt, self.custom_prompt)
 
                     # Verify our mocks were called
                     mock_init_session.assert_called_once()
@@ -63,12 +63,12 @@ class TestCustomPersonaPersistence(unittest.TestCase):
     def test_custom_prompt_persists_during_model_change(self, mock_openai):
         """Test that custom prompt persists when changing models."""
 
-        # Create a simpler test that directly tests AgentManager's handling of custom_persona_text
+        # Create a simpler test that directly tests AgentManager's handling of custom_prompt
 
         # Create a more complete mock ReactJSAgent that includes required methods
         class MockReactJSAgent:
             def __init__(self, **kwargs):
-                self.custom_persona_text = kwargs.get('custom_persona_text')
+                self.custom_prompt = kwargs.get('custom_prompt')
                 self.session_manager = None
                 self.model_name = kwargs.get('model_name')
                 self.persona_name = kwargs.get('persona_name', 'default')
@@ -93,7 +93,7 @@ class TestCustomPersonaPersistence(unittest.TestCase):
                     'initialized_tools': [],
                     'agent_name': 'MockAgent',
                     'session_id': self.session_id,
-                    'custom_prompt': self.custom_persona_text,
+                    'custom_prompt': self.custom_prompt,
                     'output_format': 'raw',
                     'created_time': self._current_timestamp(),
                     'temperature': None,
@@ -114,7 +114,7 @@ class TestCustomPersonaPersistence(unittest.TestCase):
                     llm_model="gpt-4o",
                     backend="openai",
                     persona_name="default",
-                    custom_persona_text=self.custom_prompt
+                    custom_prompt=self.custom_prompt
                 )
             )
 
@@ -122,9 +122,9 @@ class TestCustomPersonaPersistence(unittest.TestCase):
             session_data = self.agent_manager.get_session_data(session_id)
             self.assertIsNotNone(session_data)
             agent = session_data["agent"]
-            self.assertEqual(agent.custom_persona_text, self.custom_prompt)
+            self.assertEqual(agent.custom_prompt, self.custom_prompt)
 
-            # Change model - without specifying custom_persona_text again
+            # Change model - without specifying custom_prompt again
             new_session_id = self.loop.run_until_complete(
                 self.agent_manager.create_session(
                     llm_model="gpt-3.5-turbo",
@@ -140,7 +140,7 @@ class TestCustomPersonaPersistence(unittest.TestCase):
             new_agent = new_session_data["agent"]
 
             # This is the key assertion - verify the custom prompt was maintained
-            self.assertEqual(new_agent.custom_persona_text, self.custom_prompt)
+            self.assertEqual(new_agent.custom_prompt, self.custom_prompt)
 
     @patch('agent_c.agents.gpt.AsyncOpenAI')
     def test_real_agent_persists_custom_prompt_during_model_change(self, mock_openai):
@@ -169,7 +169,7 @@ class TestCustomPersonaPersistence(unittest.TestCase):
                             llm_model="gpt-4o",
                             backend="openai",
                             persona_name="default",
-                            custom_persona_text=self.custom_prompt
+                            custom_prompt=self.custom_prompt
                         )
                     )
 
@@ -177,9 +177,9 @@ class TestCustomPersonaPersistence(unittest.TestCase):
                     session_data = self.agent_manager.get_session_data(session_id)
                     self.assertIsNotNone(session_data)
                     agent = session_data["agent"]
-                    self.assertEqual(agent.custom_persona_text, self.custom_prompt)
+                    self.assertEqual(agent.custom_prompt, self.custom_prompt)
 
-                    # Change model - without specifying custom_persona_text again
+                    # Change model - without specifying custom_prompt again
                     new_session_id = self.loop.run_until_complete(
                         self.agent_manager.create_session(
                             llm_model="gpt-3.5-turbo",
@@ -195,7 +195,7 @@ class TestCustomPersonaPersistence(unittest.TestCase):
                     new_agent = new_session_data["agent"]
 
                     # This checks that the real ReactJSAgent properly maintains the prompt
-                    self.assertEqual(new_agent.custom_persona_text, self.custom_prompt)
+                    self.assertEqual(new_agent.custom_prompt, self.custom_prompt)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This pull request focuses on renaming the `custom_persona_text` attribute to `custom_prompt` across various parts of the codebase to improve clarity and consistency. The changes span multiple files, including the main agent manager and associated tests.

### Renaming of `custom_persona_text` to `custom_prompt`:

* [`src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_manager.py`](diffhunk://#diff-2c4bb947c744aebea2a57649aee31da1fa01b19205514e829b50a624d228c2e7L78-R79): Updated the `create_session` method to use `custom_prompt` instead of `custom_persona_text`. This includes the extraction of the custom prompt from `kwargs`, preserving the existing custom prompt during model changes, and initializing the agent with the new `custom_prompt` attribute. [[1]](diffhunk://#diff-2c4bb947c744aebea2a57649aee31da1fa01b19205514e829b50a624d228c2e7L78-R79) [[2]](diffhunk://#diff-2c4bb947c744aebea2a57649aee31da1fa01b19205514e829b50a624d228c2e7L90-R95) [[3]](diffhunk://#diff-2c4bb947c744aebea2a57649aee31da1fa01b19205514e829b50a624d228c2e7L105-R105)

* [`src/agent_c_api_ui/agent_c_api/src/agent_c_api/tests/persona_test.py`](diffhunk://#diff-f79f53bc52e474e469bf37fcdc827847b7ca4b7fc154de3a5d8d4d95ea50166cL40-R40): Modified test cases to reflect the renaming of `custom_persona_text` to `custom_prompt`. This includes assertions to check the persistence of the custom prompt during initialization and model changes, as well as updating mock agent configurations. [[1]](diffhunk://#diff-f79f53bc52e474e469bf37fcdc827847b7ca4b7fc154de3a5d8d4d95ea50166cL40-R40) [[2]](diffhunk://#diff-f79f53bc52e474e469bf37fcdc827847b7ca4b7fc154de3a5d8d4d95ea50166cL49-R55) [[3]](diffhunk://#diff-f79f53bc52e474e469bf37fcdc827847b7ca4b7fc154de3a5d8d4d95ea50166cL66-R71) [[4]](diffhunk://#diff-f79f53bc52e474e469bf37fcdc827847b7ca4b7fc154de3a5d8d4d95ea50166cL96-R96) [[5]](diffhunk://#diff-f79f53bc52e474e469bf37fcdc827847b7ca4b7fc154de3a5d8d4d95ea50166cL117-R127) [[6]](diffhunk://#diff-f79f53bc52e474e469bf37fcdc827847b7ca4b7fc154de3a5d8d4d95ea50166cL143-R143) [[7]](diffhunk://#diff-f79f53bc52e474e469bf37fcdc827847b7ca4b7fc154de3a5d8d4d95ea50166cL172-R182) [[8]](diffhunk://#diff-f79f53bc52e474e469bf37fcdc827847b7ca4b7fc154de3a5d8d4d95ea50166cL198-R198)