### PR TITLE
Add support for the Anthropic betas

### DIFF
--- a/ci/build_api_container.bat
+++ b/ci/build_api_container.bat
@@ -1,0 +1,1 @@
+docker build -t ghcr.io/centricconsulting/agent_c_api_dev:latest -f dockerfiles\api.Dockerfile .

--- a/ci/build_fe_container.bat
+++ b/ci/build_fe_container.bat
@@ -1,0 +1,1 @@
+docker build -t ghcr.io/centricconsulting/agent_c_frontend_dev:latest -f dockerfiles\frontend.Dockerfile .

--- a/src/agent_c_core/pyproject.toml
+++ b/src/agent_c_core/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "pydantic==2.9.2",
     "openai==1.64.0",
     "tiktoken==0.7.0",
-    "anthropic==0.47.1",
+    "anthropic==0.49.0",
     "diskcache==5.6.3",
     "observable==1.0.3",
     "sounddevice",

--- a/src/agent_c_core/src/agent_c/agents/claude.py
+++ b/src/agent_c_core/src/agent_c/agents/claude.py
@@ -67,7 +67,13 @@ class ClaudeChatAgent(BaseAgent):
 
         functions: List[Dict[str, Any]] = tool_chest.active_claude_schemas
 
-        completion_opts = {"model": model_name, "messages": messages, "system": sys_prompt,  "max_tokens": max_tokens, 'temperature': temperature}
+        completion_opts = {"model": model_name, "messages": messages,
+                           "system": sys_prompt,  "max_tokens": max_tokens,
+                           'temperature': temperature}
+
+        if '3-7-sonnet' in model_name:
+            completion_opts['betas'] = ["token-efficient-tools-2025-02-19", "output-128k-2025-02-19"]
+
         budget_tokens: int = kwargs.get("budget_tokens", self.budget_tokens)
         if budget_tokens > 0:
             completion_opts['thinking'] = {"budget_tokens": budget_tokens, "type": "enabled"}
@@ -131,7 +137,7 @@ class ClaudeChatAgent(BaseAgent):
             while delay <= self.max_delay:
                 try:
                     await self._raise_completion_start(opts["completion_opts"], **callback_opts)
-                    async with self.client.messages.stream (**opts["completion_opts"]) as stream:
+                    async with self.client.beta.messages.stream (**opts["completion_opts"]) as stream:
                         collected_messages = []
                         collected_tool_calls = []
                         input_tokens = 0


### PR DESCRIPTION
### DEPENDENCY UPDATED install deps or Claude go boom.

The Claude Chat agent will now enable two Anthropic betas when your model is 3.7-sonnet

-[ Token-efficient tool use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/token-efficient-tool-use) - This is supposed to help with the regression in 3.7 around parallel tool calls.  Note: It does NOT make it STFU while calling tools.
- output-128k-2025-02-19  - This one slipped through the cracks for me when I added the 3.7 support.  I didn't catch that 128k required a beta header.


--- 

This pull request includes several changes to the build process, dependency updates, and enhancements to the `claude` agent functionality. The most important changes are summarized below:

### Build Process Improvements:
* [`ci/build_api_container.bat`](diffhunk://#diff-39a5d1f8c630792a4b8165e6fcdfd3f7f7b9cc38d256e0f3e001190b77d75af6R1): Added a command to build the API container using the specified Dockerfile.
* [`ci/build_fe_container.bat`](diffhunk://#diff-7c5c3f0c90bbfd4d7d4a5618e4b41feb2c87c346d9930e067fda68951944cf1aR1): Added a command to build the frontend container using the specified Dockerfile.

### Dependency Updates:
* [`src/agent_c_core/pyproject.toml`](diffhunk://#diff-76974589e64d56ea3dd561ad76276387e14b3016e8fdc106bf6288f890b0e5b4L13-R13): Updated the `anthropic` dependency from version `0.47.1` to `0.49.0`.

### Enhancements to `claude` Agent:
* [`src/agent_c_core/src/agent_c/agents/claude.py`](diffhunk://#diff-d74867587f97368abcc0acaafc2f218509185212937c61d43c07a7fc5b791876L70-R76): Enhanced the `__interaction_setup` method to include `betas` options for specific model names.
* [`src/agent_c_core/src/agent_c/agents/claude.py`](diffhunk://#diff-d74867587f97368abcc0acaafc2f218509185212937c61d43c07a7fc5b791876L134-R140): Modified the `chat` method to use the `beta` stream for message completion.