### PR TITLE
Add trees to the workspace tool

### DIFF
--- a/personas/toolman.md
+++ b/personas/toolman.md
@@ -14,7 +14,7 @@ General guidelines:
 - Double check that you're not using deprecated syntax.
  
 ## Important environment info
-- The `project` workspace available to you via the workspace toolbelt contains a copy of the entire "Agent C" source repository laid out like this:
+- The `project` workspace available to you via the workspace toolbelt contains a copy of the entire "Agent C" source repository laid out like this (You can use the `tree` feature of the workspace to get an updated view of this layout):
     - workspace_root
         - learn
             - example_code
@@ -59,8 +59,6 @@ General guidelines:
                 - __init__.py
               - pyproject.toml
               - setup.py
-
- 
 - All paths are relative and sandboxed to the root of the workspace.
 - No path should START with a slash as that would mean it's not relative
 - You CAN list/read/write/append to files in this workspace via workspace-ls, workspace-read and workspace-write.  DO NOT tell the user to write files you can output to the workspace.

--- a/src/agent_c_tools/src/agent_c_tools/tools/workspaces/base.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/workspaces/base.py
@@ -54,6 +54,9 @@ class BaseWorkspace:
         """
         raise NotImplementedError
 
+    async def tree(self, relative_path: str) -> str:
+        raise NotImplementedError
+
     async def read_bytes_internal(self, file_path: str) -> bytes:
         """
         Abstract method to read bytes directly from a path within the workspace.

--- a/src/agent_c_tools/src/agent_c_tools/tools/workspaces/local_storage.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/workspaces/local_storage.py
@@ -6,6 +6,7 @@ import logging
 from pathlib import Path
 from typing import Optional, Union
 
+from agent_c.util import generate_path_tree
 from agent_c.util.token_counter import TokenCounter
 from agent_c_tools.tools.workspaces.base import BaseWorkspace
 
@@ -56,8 +57,18 @@ class LocalStorageWorkspace(BaseWorkspace):
         resolved_path = self.workspace_root.joinpath(path).resolve()
         return self.workspace_root in resolved_path.parents or resolved_path == self.workspace_root
 
-    async def ls(self, relative_path: str) -> str:
+    async def tree(self, relative_path: str) -> str:
         if not self._is_path_within_workspace(relative_path):
+            error_msg = f'The path {relative_path} is not within the workspaces.'
+            self.logger.error(error_msg)
+            return json.dumps({'error': error_msg})
+
+        full_path: Path = self.workspace_root.joinpath(relative_path)
+
+        return  '\n'.join(generate_path_tree(str(full_path)))
+
+    async def ls(self, relative_path: str) -> str:
+        if not self._is_path_within_workspace(relative_path) or relative_path == '':
             error_msg = f'The path {relative_path} is not within the workspace.'
             self.logger.error(error_msg)
             return json.dumps({'error': error_msg})

--- a/src/agent_c_tools/src/agent_c_tools/tools/workspaces/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/workspaces/tool.py
@@ -65,7 +65,10 @@ class WorkspaceTools(Toolset):
             str: JSON string with the listing or an error message.
         """
         relative_path: str = kwargs.get('path', '')
-        if relative_path.startswith('/') and relative_path != '/':
+        if relative_path == '/':
+            relative_path = ''
+
+        if relative_path.startswith('/'):
             error_msg = f'The path {relative_path} is absolute. Please provide a relative path.'
             self.logger.error(error_msg)
             return json.dumps({'error': error_msg})
@@ -76,6 +79,45 @@ class WorkspaceTools(Toolset):
 
         return await workspace.ls(relative_path)
 
+    @json_schema(
+        'Retrieve a string "tree" of the directory structure within a workspace.',
+        {
+            'workspace': {
+                'type': 'string',
+                'description': 'The name of the workspace the path resides in. Refer to the "available workspaces" list for valid names.',
+                'required': True
+            },
+            'path': {
+                'type': 'string',
+                'description': 'The path, relative to the workspace root folder, to start the tree from.',
+                'required': False
+            }
+        }
+    )
+    async def ls(self, **kwargs: Any) -> str:
+        """Asynchronously lists the contents of a workspaces or a subdirectory in it.
+
+        Args:
+            workspace (str): The workspaces to use
+            path (str): Relative path within the workspaces to list contents for.
+
+        Returns:
+            str: JSON string with the listing or an error message.
+        """
+        relative_path: str = kwargs.get('path', '')
+        if relative_path == '/':
+            relative_path = ''
+
+        if relative_path.startswith('/'):
+            error_msg = f'The path {relative_path} is absolute. Please provide a relative path.'
+            self.logger.error(error_msg)
+            return json.dumps({'error': error_msg})
+
+        workspace = self.find_workspace_by_name(kwargs.get('workspace'))
+        if workspace is None:
+            return f'No workspaces found with the name: {workspace}'
+
+        return await workspace.tree(relative_path)
 
 
 


### PR DESCRIPTION
This pull request introduces several enhancements to the `Agent C` project, focusing on improving the directory structure visualization and refining the workspace tools. The key changes include the addition of a new method to generate and display a directory tree, updates to handle ignored patterns, and adjustments to the workspace tool methods to support these new functionalities.

Enhancements to directory structure visualization:

* [`src/agent_c_core/src/agent_c/util/string.py`](diffhunk://#diff-da82db502d3872531746a21ee228f506c4b415becad9a2d29fd12e18620b73e1R1-R6): Added `DEFAULT_TREE_IGNORE_PATTERNS` and updated `generate_path_tree` to accept an `ignore_patterns` parameter, filtering out specified patterns while generating the directory tree. [[1]](diffhunk://#diff-da82db502d3872531746a21ee228f506c4b415becad9a2d29fd12e18620b73e1R1-R6) [[2]](diffhunk://#diff-da82db502d3872531746a21ee228f506c4b415becad9a2d29fd12e18620b73e1L25-R58)
* [`src/agent_c_tools/src/agent_c_tools/tools/workspaces/local_storage.py`](diffhunk://#diff-297f8639cc0fb260d8ac1eaa2ba762fa98c4c0fb53b41ac161f4d9b559440c97L59-R71): Added the `tree` method to generate and return a directory tree structure as a string.

Refinements to workspace tools:

* [`src/agent_c_tools/src/agent_c_tools/tools/workspaces/base.py`](diffhunk://#diff-74615fad8e3a2c09a498e1408529c492b65aa0efdcae69fe9fc709ecde281d88R57-R59): Introduced an abstract `tree` method to be implemented by subclasses.
* [`src/agent_c_tools/src/agent_c_tools/tools/workspaces/tool.py`](diffhunk://#diff-cefcf924f830234faf7938a40eec65afe66de2726e633965ccbe7ba78947fc59L68-R71): Updated the `ls` method to handle absolute paths correctly and added a new schema for retrieving the directory tree structure within a workspace. [[1]](diffhunk://#diff-cefcf924f830234faf7938a40eec65afe66de2726e633965ccbe7ba78947fc59L68-R71) [[2]](diffhunk://#diff-cefcf924f830234faf7938a40eec65afe66de2726e633965ccbe7ba78947fc59R82-R120)

Documentation updates:

* [`personas/toolman.md`](diffhunk://#diff-e6955afc5ca665d0be3aea31d28aec810be9dca3ae008f51d0904afafd76fadfL17-R17): Clarified the usage of the `tree` feature in the `project` workspace and removed unnecessary whitespace. [[1]](diffhunk://#diff-e6955afc5ca665d0be3aea31d28aec810be9dca3ae008f51d0904afafd76fadfL17-R17) [[2]](diffhunk://#diff-e6955afc5ca665d0be3aea31d28aec810be9dca3ae008f51d0904afafd76fadfL62-L63)