### PR TITLE
Fix the tree tool name

### DIFF
--- a/src/agent_c_tools/src/agent_c_tools/tools/workspaces/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/workspaces/tool.py
@@ -94,7 +94,7 @@ class WorkspaceTools(Toolset):
             }
         }
     )
-    async def ls(self, **kwargs: Any) -> str:
+    async def tree(self, **kwargs: Any) -> str:
         """Asynchronously lists the contents of a workspaces or a subdirectory in it.
 
         Args:


### PR DESCRIPTION
This pull request includes a change to the `src/agent_c_tools/src/agent_c_tools/tools/workspaces/tool.py` file to rename an asynchronous method for better clarity.

Method renaming:

* [`src/agent_c_tools/src/agent_c_tools/tools/workspaces/tool.py`](diffhunk://#diff-cefcf924f830234faf7938a40eec65afe66de2726e633965ccbe7ba78947fc59L97-R97): Renamed the `ls` method to `tree` to better reflect its functionality of listing the contents of a workspace or a subdirectory in it.