### PR TITLE
Added ratelimit, overload to backoff for Claude.

### DIFF
--- a/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/util/logging_utils.py
+++ b/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/util/logging_utils.py
@@ -209,6 +209,7 @@ class LoggingManager:
             "python_multipart": "WARNING",
             "anthropic": "WARNING",
             "openai": "WARNING",
+            "readability": "WARNING",
             # Add others as needed
         }
 

--- a/src/agent_c_tools/README.md
+++ b/src/agent_c_tools/README.md
@@ -23,7 +23,7 @@ The tools here work and have proven to be stable over time.  Many of them are 'd
 - [user_bio](src/agent_c_tools/tools/user_bio) - A skeleton tool for updating a users first and last name to demonstrate how you can capture/use user bio information
 - [user_preferences](src/agent_c_tools/tools/user_preferences) - A for updating a users preferences to demonstrate how you can capture/use user preferences using key/value pairs
 - [weather](src/agent_c_tools/tools/weather) - A tool for getting the current weather for a location using the python's weather API and library
-- [web](src/agent_c_tools/tools/web) - A tool for scraping web pages using headless Selenium browser
+- [web](src/agent_c_tools/tools/web) - A tool for scraping web pages using headless Selenium browser. Can format pages as markdown and save to workspaces.
 - [web_search](src/agent_c_tools/tools/web_search) - A collection of tools for searching elements of the web
   - duckduckgo - DuckDuckGo search engine queries
   - google via google serpapi - Google search engine via specified API

--- a/src/agent_c_tools/src/agent_c_tools/tools/web/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/web/tool.py
@@ -1,8 +1,11 @@
 import re
 import httpx
+import json
 import logging
+import datetime
 
 from typing import List, Optional
+from urllib.parse import urlparse
 
 from selenium import webdriver
 from selenium.webdriver.chrome.options import Options
@@ -22,7 +25,7 @@ class WebTools(Toolset):
     """
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs, name='web')
+        super().__init__(**kwargs, name='web', required_tools=['workspace'])
         self.default_formatter: ContentFormatter = kwargs.get('wt_default_formatter', ReadableFormatter(re.compile(r".*")))
         self.formatters: List[ContentFormatter] = kwargs.get('wt_formatters', [])
         self.driver = self.__init__wd()
@@ -96,6 +99,23 @@ class WebTools(Toolset):
                 'type': 'string',
                 'description': 'The URL of the web page you would like to fetch',
                 'required': True
+            },
+            'save_to_workspace': {
+                'type': 'boolean',
+                'description': 'Whether to save the markdown content to a workspace',
+                'required': False,
+                'default': False
+            },
+            'workspace_name': {
+                'type': 'string',
+                'description': 'Workspace name to use for saving the markdown file',
+                'required': False,
+                'default': 'project'
+            },
+            'file_path': {
+                'type': 'string',
+                'description': 'File path within the workspace to save the markdown file',
+                'required': False
             }
         }
     )
@@ -105,13 +125,23 @@ class WebTools(Toolset):
 
         Args:
             **kwargs: Keyword arguments containing the 'url' and possibly other configuration details.
+                url: The URL of the web page to fetch
+                raw: Whether to return the raw HTML instead of formatted markdown
+                expire_secs: How long to cache the content
+                save_to_workspace: Whether to save the markdown content to a workspace
+                workspace_name: Workspace name to use for saving the markdown file
+                file_path: File path within the workspace to save the markdown file
 
         Returns:
             str: Page content in Markdown format or an error message if an exception occurs.
+                 If saving to workspace, returns a JSON string with the status.
         """
         url: str = kwargs.get('url')
         raw: bool = kwargs.get("raw", False)
         default_expire: int = kwargs.get("expire_secs", 3600)
+        save_to_workspace: bool = kwargs.get("save_to_workspace", False)
+        workspace_name: str = kwargs.get("workspace_name", "project")
+        file_path: str = kwargs.get("file_path", None)
 
         if url is None:
             return 'url is required'
@@ -144,7 +174,59 @@ class WebTools(Toolset):
                     self.tool_cache.set(url, response_content, expire=default_expire)
                     logging.debug(f'URL cached with default expiration: {url}')
 
-                return response_content
+                # If save_to_workspace is true, save the content to the specified workspace
+                if save_to_workspace:
+                    try:
+                        # If file_path is not provided, generate one based on the URL
+                        if file_path is None:
+                            # Extract domain from URL and create a clean filename
+                            from urllib.parse import urlparse
+                            parsed_url = urlparse(url)
+                            domain = parsed_url.netloc.replace('.', '_')
+                            timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+
+                            file_path = f"{domain}_{timestamp}.md"
+                        
+                        # Ensure file has .md extension
+                        if not file_path.endswith('.md'):
+                            file_path = f"{file_path}.md"
+                        
+                        # Get workspace toolset
+                        workspace_tool = self.tool_chest.active_tools.get("workspace")
+                        if workspace_tool is None:
+                            return json.dumps({
+                                'error': "Workspace tool not available. Cannot save markdown.",
+                                'content': response_content
+                            })
+                        
+                        # Find the workspace and save the content
+                        workspace_obj = workspace_tool.find_workspace_by_name(workspace_name)
+                        if workspace_obj is None:
+                            return json.dumps({
+                                'error': f"No workspace found with the name: {workspace_name}",
+                                'content': response_content
+                            })
+                        
+                        # Save the markdown content to the workspace
+                        result = await workspace_obj.write(file_path=file_path, mode='write', data=response_content)
+                        logging.info(f'Saved webpage content to workspace: {workspace_name} with file name: {file_path}')
+                        
+                        return json.dumps({
+                            'result': result,
+                            'message': f"Webpage content saved to {workspace_name}/{file_path}",
+                            'file_path': file_path,
+                            'workspace_name': workspace_name
+                        })
+                        
+                    except Exception as e:
+                        logging.error(f'Error saving to workspace: {str(e)}')
+                        return json.dumps({
+                            'error': f'Error saving to workspace: {str(e)}',
+                            'content': response_content,
+                            'result': result if result is not None else None
+                        })
+                else:
+                    return response_content
             except httpx.HTTPStatusError as e:
                 logging.error(f'HTTP error occurred: {e}')
                 return f'HTTP error occurred: {e}'


### PR DESCRIPTION
This pull request includes several updates to the `agent_c` project, focusing on improving error handling, adding new features for web scraping tools, and updating logging configurations.

Error Handling Enhancements:
* Added `RateLimitError` and `OverloadedError` to the list of exceptions handled in the `chat` method of the `Claude` agent. The system now logs the specific error type and performs exponential backoff accordingly.

Web Scraping Tool Enhancements:
* Updated the `web` tool to include options for saving scraped web pages as markdown files to workspaces. New parameters `save_to_workspace`, `workspace_name`, and `file_path` were added to the `open_webpage` and `fetch_webpage` methods. [[1]](diffhunk://#diff-1906871bc5bdabcc8a7b7cceb977bbb980e010f44eb12bd09a3b236e22c2aa9eR102-R118) [[2]](diffhunk://#diff-1906871bc5bdabcc8a7b7cceb977bbb980e010f44eb12bd09a3b236e22c2aa9eR128-R144) [[3]](diffhunk://#diff-1906871bc5bdabcc8a7b7cceb977bbb980e010f44eb12bd09a3b236e22c2aa9eR177-R228)
* Modified the `WebTools` class to require the `workspace` tool for saving markdown files.

Logging Configuration Update:
* Added a new logger configuration for `readability` in the `configure_external_loggers` method to set its logging level to `WARNING`.

Documentation Update:
* Updated the `web` tool description in the `README.md` file to reflect the new feature of formatting pages as markdown and saving them to workspaces.Added save web page to markdown to web tools
Removed noisy readability logger