### PR TITLE
Mcp2

### DIFF
--- a/src/agent_c_core/src/agent_c/toolsets/mcp_server.py
+++ b/src/agent_c_core/src/agent_c/toolsets/mcp_server.py
@@ -373,6 +373,9 @@ class MCPServer:
             ValueError: If the tool does not exist
         """
         if not self.connected or not self.session:
+            await self.connect()
+
+        if not self.connected or not self.session:
             raise RuntimeError(f"Server {self.server_id} is not connected")
         
         if tool_name not in self.tools:

--- a/src/agent_c_core/src/agent_c/toolsets/mcp_toolset.py
+++ b/src/agent_c_core/src/agent_c/toolsets/mcp_toolset.py
@@ -29,7 +29,7 @@ class MCPToolset(Toolset):
         """
         # Initialize with a name based on the server ID
         name = kwargs.pop("name", f"mcp_{server.server_id}")
-        super().__init__(name=name, **kwargs)
+        super().__init__(name=name, use_prefix=False, **kwargs)
         self.openai_schemas = []
         self.server = server
         self.logger = logging.getLogger(f"agent_c.mcp_toolset.{server.server_id}")
@@ -53,7 +53,6 @@ class MCPToolset(Toolset):
             method_name = f"{tool_name.replace('-', '_')}"
             setattr(self, method_name, method)
             schema = copy.deepcopy(method.schema)
-            schema['function']['name'] = f"{self.name}{Toolset.tool_sep}{schema['function']['name']}"
             self.openai_schemas.append(schema)
             self.logger.info(f"Created method {method_name} for MCP tool {tool_name}")
     

--- a/src/agent_c_core/src/agent_c/toolsets/tool_chest.py
+++ b/src/agent_c_core/src/agent_c/toolsets/tool_chest.py
@@ -268,20 +268,12 @@ class ToolChest:
         """
 
         src_obj: Toolset = self._tool_name_to_instance_map.get(function_id)
-        if src_obj is not None:
-            function_name = function_id
-        else:
-            toolset, function_name = function_id.split(Toolset.tool_sep, 1)
-            src_obj: Toolset = self.active_tools[toolset]
-        
+        if src_obj is None:
+            return f"{function_id} is not on a valid toolset."
         try:
-            if src_obj is None:
-                return f"{function_name} is not on a valid toolset."
-
-            function_to_call: Any = getattr(src_obj, function_name)
-            return await function_to_call(**function_args)
+            return await src_obj.call(function_id, function_args)
         except Exception as e:
-            logging.exception(f"Failed calling {function_name} on {toolset}. {e}")
-            return f"Important! Tell the user an error occurred calling {function_name} on {toolset}. {e}"
+            logging.exception(f"Failed calling {function_id} on {src_obj.name}. {e}", stacklevel=3)
+            return f"Important! Tell the user an error occurred calling {function_id} on {src_obj.name}. {e}"
 
 

--- a/src/agent_c_core/src/agent_c/toolsets/tool_set.py
+++ b/src/agent_c_core/src/agent_c/toolsets/tool_set.py
@@ -12,7 +12,7 @@ from agent_c.chat.session_manager import ChatSessionManager
 
 class Toolset:
     tool_registry: List[Any] = []
-    tool_sep: str = "-"
+    tool_sep: str = "_"
 
     @classmethod
     def register(cls, tool_cls: Any) -> None:
@@ -51,6 +51,7 @@ class Toolset:
 
         self.session_manager: ChatSessionManager = kwargs.get("session_manager")
         self.tool_chest: 'ToolChest' = kwargs.get("tool_chest")
+        self.use_prefix: bool = kwargs.get("use_prefix", True)
 
         # Handle required tools activation
         required_tools: List[str] = kwargs.get("required_tools", [])
@@ -217,7 +218,8 @@ class Toolset:
         for name, method in inspect.getmembers(self, predicate=inspect.ismethod):
             if hasattr(method, 'schema'):
                 schema = copy.deepcopy(method.schema)
-                schema['function']['name'] = f"{self.name}{Toolset.tool_sep}{schema['function']['name']}"
+                if self.use_prefix:
+                    schema['function']['name'] = f"{self.name}{Toolset.tool_sep}{schema['function']['name']}"
                 openai_schemas.append(schema)
 
         return openai_schemas

--- a/src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/tool.py
@@ -17,7 +17,7 @@ class MarkdownToHtmlReportTools(Toolset):
     """Toolset for generating interactive HTML viewers from markdown files in a workspace."""
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs, name="markdown_viewer")
+        super().__init__(**kwargs, name="markdown_viewer", use_prefix=False)
         # Get workspace tools for file operations
         self.workspace_tool = self.tool_chest.active_tools.get('workspace')
         if not self.workspace_tool:
@@ -57,7 +57,7 @@ class MarkdownToHtmlReportTools(Toolset):
             }
         }
     )
-    async def generate_report(self, **kwargs) -> str:
+    async def generate_md_viewer(self, **kwargs) -> str:
         """Generate an interactive HTML viewer for markdown files in a workspace directory.
 
         Args:

--- a/src/agent_c_tools/src/agent_c_tools/tools/mermaid_chart/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/mermaid_chart/tool.py
@@ -8,7 +8,7 @@ from agent_c.util.string import to_snake_case
 class MermaidChartTools(Toolset):
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs, name='mermaidchart', tool_role='mermaid_chart', section=MermaidChatSection())
+        super().__init__(**kwargs, name='mermaid', tool_role='mermaid_chart', section=MermaidChatSection())
 
     @json_schema(
         'Render a mermaid.js graph and return the SVG link.',

--- a/src/agent_c_tools/src/agent_c_tools/tools/random_number/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/random_number/tool.py
@@ -16,7 +16,7 @@ class RandomNumberTools(Toolset):
         Args:
             **kwargs: Keyword arguments passed to parent Toolset class.
         """
-        super().__init__(**kwargs, name='random_number_generator')
+        super().__init__(**kwargs, name='rng')
         self.logger = logging.getLogger(__name__)
         # self.logger.debug(
         #     f"RandomNumberTools initialized with streaming_callback: {self.streaming_callback is not None}")

--- a/src/agent_c_tools/src/agent_c_tools/tools/think/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/think/tool.py
@@ -12,7 +12,7 @@ class ThinkTools(Toolset):
     A simple toolset that allows reasoning models (claude) to think about something.
     """
     def __init__(self, **kwargs):
-        super().__init__(**kwargs, name='think', required_tools=['workspace'])
+        super().__init__(**kwargs, name='think', required_tools=['workspace'], use_prefix=False)
         self.logger = logging.getLogger(__name__)
 
         # TODO: Remove this when the new tools go in.

--- a/src/agent_c_tools/src/agent_c_tools/tools/weather/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/weather/tool.py
@@ -9,7 +9,7 @@ from agent_c import json_schema, Toolset
 class WeatherTools(Toolset):
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs, name='weather')
+        super().__init__(**kwargs, name='weather', use_prefix=False)
         self.logger: logging.Logger = logging.getLogger(__name__)
 
     @json_schema(

--- a/src/agent_c_tools/src/agent_c_tools/tools/web/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/web/tool.py
@@ -25,7 +25,7 @@ class WebTools(Toolset):
     """
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs, name='web', required_tools=['workspace'])
+        super().__init__(**kwargs, name='web', required_tools=['workspace'], use_prefix=False)
         self.default_formatter: ContentFormatter = kwargs.get('wt_default_formatter', ReadableFormatter(re.compile(r".*")))
         self.formatters: List[ContentFormatter] = kwargs.get('wt_formatters', [])
         self.driver = self.__init__wd()

--- a/src/agent_c_tools/src/agent_c_tools/tools/web_search/duck_duck_go/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/web_search/duck_duck_go/tool.py
@@ -5,7 +5,7 @@ from agent_c.toolsets import json_schema, Toolset
 # A tool belt for asynchronous search functionality using the DuckDuckGo search API.
 class DuckDuckGoTools(Toolset):
     def __init__(self, **kwargs):
-        super().__init__(**kwargs, name='duckduckgo')
+        super().__init__(**kwargs, name='ddg')
 
     @json_schema(
         'Perform a web search using DuckDuckGo.',

--- a/src/agent_c_tools/src/agent_c_tools/tools/web_search/hacker_news/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/web_search/hacker_news/tool.py
@@ -7,7 +7,7 @@ from agent_c.toolsets import json_schema, Toolset
 class HackerNewsTools(Toolset):
 
     def __init__(self, **kwargs):
-        super().__init__(**kwargs, name='hacker_news')
+        super().__init__(**kwargs, name='hn')
         self.base_url = 'https://hacker-news.firebaseio.com/v0/'
 
     @json_schema(


### PR DESCRIPTION
This finishes the refactoring of how tools are called.  Instead of relying on a prefix to map to the toolset name, we now map each tool name to a toolset and let the toolset sort out which method to call based on the toolname.  This removes the need for any other piece of agent C to know the internal workings of a toolset.

**With this change it's not possible for the UI skip loading of most tools directly and use a tool server**

Tools that rely on other tools should really still be in process for a while yet.

--- 
This pull request introduces several enhancements and refactorings to the `agent_c_core` and `agent_c_tools` modules, focusing on improving toolset initialization, method naming conventions, and tool call execution.

### Enhancements to toolset initialization and method execution:

* [`src/agent_c_core/src/agent_c/toolsets/mcp_server.py`](diffhunk://#diff-5e8596679001c25a4f2c5fba96ca8161a284158d209b6407aa6f0c3b940431a6R375-R377): Added a connection check and automatic reconnection mechanism in the `call_tool` method.
* [`src/agent_c_core/src/agent_c/toolsets/tool_chest.py`](diffhunk://#diff-884f927a285f241b97e63a19251a65a5bd6334aabef2b89ccca43380aff4e3e3R48): Added a mapping from tool names to instances and improved the tool initialization process to log added tools and update the mapping. [[1]](diffhunk://#diff-884f927a285f241b97e63a19251a65a5bd6334aabef2b89ccca43380aff4e3e3R48) [[2]](diffhunk://#diff-884f927a285f241b97e63a19251a65a5bd6334aabef2b89ccca43380aff4e3e3R137-R138) [[3]](diffhunk://#diff-884f927a285f241b97e63a19251a65a5bd6334aabef2b89ccca43380aff4e3e3R149) [[4]](diffhunk://#diff-884f927a285f241b97e63a19251a65a5bd6334aabef2b89ccca43380aff4e3e3R158-R169)
* [`src/agent_c_core/src/agent_c/toolsets/tool_chest.py`](diffhunk://#diff-884f927a285f241b97e63a19251a65a5bd6334aabef2b89ccca43380aff4e3e3L258-R277): Refactored the `_execute_tool_call` method to use the new tool name to instance mapping for improved tool call execution.

### Changes to method naming conventions:

* [`src/agent_c_core/src/agent_c/toolsets/mcp_toolset.py`](diffhunk://#diff-9f752410bff9bbb588b9fa6e23436267b5e579e5ffd8e3b8abd4192701e0fc03L56): Removed the prefix from method names in the `_create_tool_methods` method.
* [`src/agent_c_core/src/agent_c/toolsets/tool_set.py`](diffhunk://#diff-f62940b76b30c07afce8cdbc1201380588567e659bbca253f8f2664a0691d818R54): Introduced a `prefix` property and a `call` method to handle tool calls with or without prefixes. [[1]](diffhunk://#diff-f62940b76b30c07afce8cdbc1201380588567e659bbca253f8f2664a0691d818R54) [[2]](diffhunk://#diff-f62940b76b30c07afce8cdbc1201380588567e659bbca253f8f2664a0691d818R86-R113) [[3]](diffhunk://#diff-f62940b76b30c07afce8cdbc1201380588567e659bbca253f8f2664a0691d818L220-R250)
* [`src/agent_c_core/src/agent_c/toolsets/tool_set.py`](diffhunk://#diff-f62940b76b30c07afce8cdbc1201380588567e659bbca253f8f2664a0691d818L15-R15): Changed the tool separator from `-` to `_` to standardize method naming.

### Updates to specific toolsets:

* [`src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/tool.py`](diffhunk://#diff-5af3da31ce84f1fab1a804d56dc22834fafe3a83f0b3cb699074b862cbb65e68L20-R20): Updated the `MarkdownToHtmlReportTools` to disable the prefix and renamed the `generate_report` method to `generate_md_viewer`. [[1]](diffhunk://#diff-5af3da31ce84f1fab1a804d56dc22834fafe3a83f0b3cb699074b862cbb65e68L20-R20) [[2]](diffhunk://#diff-5af3da31ce84f1fab1a804d56dc22834fafe3a83f0b3cb699074b862cbb65e68L60-R60)
* [`src/agent_c_tools/src/agent_c_tools/tools/mermaid_chart/tool.py`](diffhunk://#diff-f0fddb41e9802ccb67fbebfd2c14c9e57792e1ada10f402954cf5a99fddf4728L11-R11): Renamed the `mermaidchart` toolset to `mermaid`.
* [`src/agent_c_tools/src/agent_c_tools/tools/think/tool.py`](diffhunk://#diff-9ec71ee58047d0b30c4915e86bd08ac03d0fcd70e74e8bea2e6dc62897cc3dd0L15-R15): Disabled the prefix for the `ThinkTools` toolset.
* [`src/agent_c_tools/src/agent_c_tools/tools/weather/tool.py`](diffhunk://#diff-8a613ef346a14551e57c69474f233ce91dcb0e9f75e706a69be3e691eecd7efcL12-R12): Disabled the prefix for the `WeatherTools` toolset.
* [`src/agent_c_tools/src/agent_c_tools/tools/web/tool.py`](diffhunk://#diff-1906871bc5bdabcc8a7b7cceb977bbb980e010f44eb12bd09a3b236e22c2aa9eL28-R28): Disabled the prefix for the `WebTools` toolset.
* [`src/agent_c_tools/src/agent_c_tools/tools/web_search/duck_duck_go/tool.py`](diffhunk://#diff-1e60deb7638cc8c4af4e2ee7bb19810c1a4f0ce80913cdf14cb07a478268a542L8-R8): Renamed the `duckduckgo` toolset to `ddg`.
* [`src/agent_c_tools/src/agent_c_tools/tools/web_search/hacker_news/tool.py`](diffhunk://#diff-e53302a64bd6f65e8392ffd5da6cbeed43a5c8207b055733b0b4347d6765c975L10-R10): Renamed the `hacker_news` toolset to `hn`.