### PR TITLE
Change tree size for personas

### DIFF
--- a/src/agent_c_core/src/agent_c/prompting/basic_sections/persona.py
+++ b/src/agent_c_core/src/agent_c/prompting/basic_sections/persona.py
@@ -96,7 +96,7 @@ class DynamicPersonaSection(PromptSection):
         if ws_name:
             ws_tool = context['tool_chest'].active_tools.get('workspace')
 
-            tree = await ws_tool.tree(path=f"//{ws_name}/", folder_depth=7, file_depth=7)
+            tree = await ws_tool.tree(path=f"//{ws_name}/", folder_depth=5, file_depth=2)
             context['workspace_tree'] = f"Generated: {self.timestamp()}\n{tree}"
 
         template: Template = Template(base_prompt, )


### PR DESCRIPTION
This pull request makes a minor adjustment to the `rendered_persona_prompt` method in the `persona.py` file to reduce the depth of the workspace tree retrieval.

Key change:

* [`src/agent_c_core/src/agent_c/prompting/basic_sections/persona.py`](diffhunk://#diff-7395d7a06588f54c8751a6861042068a9de0af646b8db59909cfcc9c3edf1b80L99-R99): Updated the `tree` method call to reduce `folder_depth` from 7 to 5 and `file_depth` from 7 to 2, optimizing the workspace tree retrieval process for efficiency.