### PR TITLE
Removing MemoryTool from agent_manager.py

### DIFF
--- a/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_manager.py
+++ b/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_manager.py
@@ -24,7 +24,7 @@ class UItoAgentBridgeManager:
         ui_sessions (Dict[str, Dict[str, Any]]): Active session storage
         _locks (Dict[str, asyncio.Lock]): Session operation locks
     """
-    ESSENTIAL_TOOLS = ['MemoryTools', 'WorkspaceTools', 'ThinkTools', 'RandomNumberTools', 'MarkdownToHtmlReportTools']
+    ESSENTIAL_TOOLS = ['WorkspaceTools', 'ThinkTools', 'RandomNumberTools', 'MarkdownToHtmlReportTools']
 
     def __init__(self):
         logging_manager = LoggingManager(__name__)


### PR DESCRIPTION
This pull request makes a small change to the `ESSENTIAL_TOOLS` list in the `UItoAgentBridgeManager` class by removing the `MemoryTools` entry. This change reduces the set of essential tools used in the `agent_manager.py` file.