### PR TITLE
Missed a scection in the prompt refactor

### DIFF
--- a/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_bridge.py
+++ b/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_bridge.py
@@ -23,7 +23,7 @@ from agent_c_tools.tools.workspace import LocalStorageWorkspace
 from agent_c_tools.tools.random_number import RandomNumberTools
 from agent_c.toolsets import ToolChest, ToolCache, Toolset
 from agent_c.toolsets.mcp_tool_chest import MCPToolChest, MCPServer
-
+from agent_c_tools.tools.think.prompt import ThinkSection
 from agent_c.chat import ChatSessionManager
 
 #from agent_c_tools.tools.user_preferences import AssistantPersonalityPreference, AddressMeAsPreference, UserPreference
@@ -382,6 +382,7 @@ class AgentBridge:
         """
         operating_sections = [
             CoreInstructionSection(),
+            ThinkSection(),
             DynamicPersonaSection()
         ]
 


### PR DESCRIPTION
This pull request introduces a minor enhancement to the `agent_bridge.py` file by incorporating a new section into the agent's initialization process, which could potentially improve its functionality.

Enhancements to agent initialization:

* [`src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_bridge.py`](diffhunk://#diff-28bc5184f60b617647c44cd86d7e90885fee567cc04bad4bdf9ffda2f4e533d7L26-R26): Added the `ThinkSection` import and included it in the `operating_sections` list within the `initialize_agent_parameters` method. This change likely enables the agent to utilize additional capabilities or logic provided by the `ThinkSection`. [[1]](diffhunk://#diff-28bc5184f60b617647c44cd86d7e90885fee567cc04bad4bdf9ffda2f4e533d7L26-R26) [[2]](diffhunk://#diff-28bc5184f60b617647c44cd86d7e90885fee567cc04bad4bdf9ffda2f4e533d7R385)