### PR TITLE
Make markdown report titles pretty

### DIFF
--- a/personas/cora-agent_c_core_dev.md
+++ b/personas/cora-agent_c_core_dev.md
@@ -62,8 +62,7 @@ The company has a strict policy against AI performing code modifications without
 - **Scratchpad requires extra thought:** After reading in the content from the scratchpad you MUST make use of the think tool to reflect and map out what you're going to do so things are done right.
 
 - Be mindful of token consumption, use the most efficient workspace tools for the job:
-  - The design for the tool is included below. Use this as a baseline knowledgebase instead of digging through all the files each time. 
-  - Favor the use of `replace_strings` and performing batch updates. **Some workspaces may be remote, batching saves bandwidth.**
+  
 
 ## Unit Testing Rules
 - You can NOT run test scripts so don't try

--- a/src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/markdown-viewer-template.html
+++ b/src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/markdown-viewer-template.html
@@ -652,81 +652,100 @@
         
         // Function to create the tree view
         function createTreeView(structure, parent) {
-            structure.forEach(item => {
-                const li = document.createElement('li');
-                
-                if (item.type === 'folder') {
-                    // Create folder
-                    const folderElement = document.createElement('div');
-                    folderElement.classList.add('folder');
-                    folderElement.textContent = item.name;
-                    li.appendChild(folderElement);
-                    
-                    // Create child list for this folder
-                    const ul = document.createElement('ul');
-                    ul.classList.add('tree-view', 'hidden');
-                    li.appendChild(ul);
-                    
-                    // Toggle visibility on click
-                    folderElement.addEventListener('click', (e) => {
-                        e.stopPropagation();
-                        folderElement.classList.toggle('open');
-                        ul.classList.toggle('hidden');
-                    });
-                    
-                    // If there are children, create their views
-                    if (item.children && item.children.length > 0) {
-                        createTreeView(item.children, ul);
-                        
-                        // Auto-expand folders with only one sub-folder
-                        if (item.children.length === 1 && item.children[0].type === 'folder') {
-                            folderElement.classList.add('open');
-                            ul.classList.remove('hidden');
-                        }
-                    }
-                } else {
-                    // Create file
-                    // Only show markdown files
-                    if (item.name.toLowerCase().endsWith('.md') || item.name.toLowerCase().endsWith('.markdown')) {
-                        const fileElement = document.createElement('div');
-                        fileElement.classList.add('file');
-                        fileElement.textContent = item.name;
-                        fileElement.dataset.path = item.path;
-                        fileElement.dataset.content = item.content;
-                        li.appendChild(fileElement);
-                        
-                        // Handle file click to display content
-                        fileElement.addEventListener('click', (e) => {
-                            e.stopPropagation();
-                            // Remove active from all files
-                            document.querySelectorAll('.file.active').forEach(el => {
-                                el.classList.remove('active');
-                            });
-                            // Add active to this file
-                            fileElement.classList.add('active');
-                            
-                            // Render markdown content
-                            renderMarkdown(fileElement.dataset.content);
-                            
-                            // Update browser history to allow back/forward navigation
-                            updateHistory(item.path);
-                            
-                            // On mobile, collapse sidebar after selection
-                            if (window.innerWidth <= 768) {
-                                sidebarHidden = true;
-                                sidebar.style.maxHeight = '40px';
-                                sidebar.style.overflow = 'hidden';
-                            }
-                        });
-                    } else {
-                        // Skip non-markdown files
-                        return;
-                    }
-                }
-                
-                parent.appendChild(li);
+    // Helper function to format display names
+    function formatDisplayName(filename) {
+        // Remove leading numbers and dots (e.g., "01.")
+        let displayName = filename.replace(/^\d+\./, '');
+
+        // Remove file extensions (.md or .markdown)
+        displayName = displayName.replace(/\.(md|markdown)$/i, '');
+
+        // Replace underscores with spaces
+        displayName = displayName.replace(/_/g, ' ');
+
+        // Title case (capitalize first letter of each word)
+        displayName = displayName.split(' ')
+            .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(' ');
+
+        return displayName;
+    }
+
+    structure.forEach(item => {
+        const li = document.createElement('li');
+
+        if (item.type === 'folder') {
+            // Create folder
+            const folderElement = document.createElement('div');
+            folderElement.classList.add('folder');
+            folderElement.textContent = formatDisplayName(item.name); // Format folder name
+            li.appendChild(folderElement);
+
+            // Create child list for this folder
+            const ul = document.createElement('ul');
+            ul.classList.add('tree-view', 'hidden');
+            li.appendChild(ul);
+
+            // Toggle visibility on click
+            folderElement.addEventListener('click', (e) => {
+                e.stopPropagation();
+                folderElement.classList.toggle('open');
+                ul.classList.toggle('hidden');
             });
+
+            // If there are children, create their views
+            if (item.children && item.children.length > 0) {
+                createTreeView(item.children, ul);
+
+                // Auto-expand folders with only one sub-folder
+                if (item.children.length === 1 && item.children[0].type === 'folder') {
+                    folderElement.classList.add('open');
+                    ul.classList.remove('hidden');
+                }
+            }
+        } else {
+            // Create file
+            // Only show markdown files
+            if (item.name.toLowerCase().endsWith('.md') || item.name.toLowerCase().endsWith('.markdown')) {
+                const fileElement = document.createElement('div');
+                fileElement.classList.add('file');
+                fileElement.textContent = formatDisplayName(item.name); // Format file name
+                fileElement.dataset.path = item.path;
+                fileElement.dataset.content = item.content;
+                li.appendChild(fileElement);
+
+                // Handle file click to display content
+                fileElement.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    // Remove active from all files
+                    document.querySelectorAll('.file.active').forEach(el => {
+                        el.classList.remove('active');
+                    });
+                    // Add active to this file
+                    fileElement.classList.add('active');
+
+                    // Render markdown content
+                    renderMarkdown(fileElement.dataset.content);
+
+                    // Update browser history to allow back/forward navigation
+                    updateHistory(item.path);
+
+                    // On mobile, collapse sidebar after selection
+                    if (window.innerWidth <= 768) {
+                        sidebarHidden = true;
+                        sidebar.style.maxHeight = '40px';
+                        sidebar.style.overflow = 'hidden';
+                    }
+                });
+            } else {
+                // Skip non-markdown files
+                return;
+            }
         }
+
+        parent.appendChild(li);
+    });
+}
         
         // Function to render markdown
         function renderMarkdown(content) {


### PR DESCRIPTION
This pull request introduces improvements to the `Agent C Output Viewer` for better user experience and removes redundant guidance in the scratchpad documentation. The key changes include adding a helper function to format file and folder names in the tree view and cleaning up unnecessary scratchpad instructions.

### Improvements to `Agent C Output Viewer`:

* Added a `formatDisplayName` helper function to clean and format file and folder names. This includes removing leading numbers, file extensions, and underscores, and applying title case for better readability. (`src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/markdown-viewer-template.html`, [src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/markdown-viewer-template.htmlR655-R681](diffhunk://#diff-ff3e1ec512e4d8f104d4753eb83b8efe6c4561bab01e29b68d99244e3976f2daR655-R681))
* Updated the folder and file name rendering in the tree view to use the `formatDisplayName` function, improving the display of names in the UI. (`src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/markdown-viewer-template.html`, [src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/markdown-viewer-template.htmlL693-R712](diffhunk://#diff-ff3e1ec512e4d8f104d4753eb83b8efe6c4561bab01e29b68d99244e3976f2daL693-R712))

### Documentation cleanup:

* Removed redundant instructions about scratchpad usage, such as avoiding unnecessary file digging and batching updates, to streamline the documentation. (`personas/cora-agent_c_core_dev.md`, [personas/cora-agent_c_core_dev.mdL65-R65](diffhunk://#diff-fd46072809a6d1ed178cfe8926f98d9264cf062474c3e40dc5de3f51e9e8ef38L65-R65))