### PR TITLE
Created internal write_bytes method on tool.  Updated markdown tool t…

### DIFF
--- a/src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/tool.py
@@ -595,28 +595,6 @@ class MarkdownToHtmlReportTools(Toolset):
     async def _get_html_template(self) -> str:
         """Get the HTML template for the markdown viewer."""
         try:
-            # To get the template from the workspace
-            # We're going to use local file only for now
-            # workspace_template_paths = [
-            #     "//tools/src/agent_c_tools/tools/markdown_viewer/markdown-viewer-template.html",
-            #     "//tools/src/markdown-viewer-template.html",
-            #     "//tools/markdown-viewer-template.html"
-            # ]
-            #
-            # # Try reading from workspace first
-            # for template_path in workspace_template_paths:
-            #     try:
-            #         read_result = await self.workspace_tool.read(path=template_path)
-            #         read_data = json.loads(read_result)
-            #
-            #         if 'error' not in read_data:
-            #             logger.info(f"Found template in workspace: {template_path}")
-            #             return read_data.get('contents', '')
-            #     except Exception:
-            #         # Continue to the next path if this one fails
-            #         pass
-
-
             # If no workspace template found, try local file system
             local_template_path = Path(__file__).parent / "markdown-viewer-template.html"
 
@@ -792,11 +770,10 @@ class MarkdownToHtmlReportTools(Toolset):
             docx_content_bytes = await self._convert_markdown_to_docx_bytes(md_content, style, include_toc, page_break_level)
 
             try:
-                write_result = await self.workspace_tool.write(
+                write_result = await self.workspace_tool.internal_write_bytes(
                     path=output_path_full,
                     data=docx_content_bytes,
                     mode="write",
-                    data_type="binary"
                 )
             except Exception as e:
                 logger.error(f"Error writing docx file: {e}")

--- a/src/agent_c_tools/src/agent_c_tools/tools/workspace/local_storage.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/workspace/local_storage.py
@@ -188,7 +188,7 @@ class LocalStorageWorkspace(BaseWorkspace):
                 return self._error_response(f'The path {file_path} does not exist.')
 
             if full_path.is_file():
-                with open(full_path, 'r', encoding='utf-8') as file:
+                with open(full_path, 'r', encoding='utf-8', errors='replace') as file:
                     contents = file.read()
                     if len(contents):
                         file_tokens = TokenCounter.count(contents)


### PR DESCRIPTION
This pull request introduces several changes to improve file handling and simplify the codebase in the `agent_c_tools` package. The most significant updates include removing unused code for workspace template handling, adding a new internal method for binary file writing, and enhancing error handling during file reading. Below is a breakdown of the key changes:

### File Handling Improvements:
* Removed unused code for attempting to retrieve HTML templates from workspace paths in `_get_html_template`, simplifying the logic to rely solely on local file system templates. (`[src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/tool.pyL598-L619](diffhunk://#diff-5af3da31ce84f1fab1a804d56dc22834fafe3a83f0b3cb699074b862cbb65e68L598-L619)`)
* Added a new method `internal_write_bytes` to handle binary file writing internally, separating it from the existing `write` method and improving clarity. (`[src/agent_c_tools/src/agent_c_tools/tools/workspace/tool.pyL232-R249](diffhunk://#diff-976a05154098ea3a00cfc53aced20fa20d459c68732d32a83c95a832e45b9fd2L232-R249)`)

### Error Handling Enhancements:
* Enhanced file reading in `local_storage.py` by adding `errors='replace'` to the `open` function, ensuring that invalid characters in file contents are replaced rather than causing errors. (`[src/agent_c_tools/src/agent_c_tools/tools/workspace/local_storage.pyL191-R191](diffhunk://#diff-4823fbec81d92cbc7dce6433774154eff330954f9fe968dbb02d3f1c4668164dL191-R191)`)

### Codebase Simplification:
* Removed the `data_type` parameter from the `write` method, as binary writing is now handled by the new `internal_write_bytes` method. (`[[1]](diffhunk://#diff-976a05154098ea3a00cfc53aced20fa20d459c68732d32a83c95a832e45b9fd2L207-L213)`, `[[2]](diffhunk://#diff-976a05154098ea3a00cfc53aced20fa20d459c68732d32a83c95a832e45b9fd2L232-R249)`)
* Updated imports in `workspace/tool.py` to include `Union` for type annotations, aligning with the new method signature for `internal_write_bytes`. (`[src/agent_c_tools/src/agent_c_tools/tools/workspace/tool.pyL4-R4](diffhunk://#diff-976a05154098ea3a00cfc53aced20fa20d459c68732d32a83c95a832e45b9fd2L4-R4)`)…o use this.  Also added UTF-8 encoding errors to replace for reading files.