### PR TITLE
THe main function was changed from self._validate... to self.validate...

### DIFF
--- a/src/agent_c_tools/src/agent_c_tools/tools/workspace/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/workspace/tool.py
@@ -115,7 +115,7 @@ class WorkspaceTools(Toolset):
         """
         unc_path = kwargs.get('path', '')
 
-        error, workspace, relative_path = self._validate_and_get_workspace_path(unc_path)
+        error, workspace, relative_path = self.validate_and_get_workspace_path(unc_path)
         if error:
             return json.dumps({'error': error})
 
@@ -241,7 +241,7 @@ class WorkspaceTools(Toolset):
             str: JSON string with a success message or an error message.
         """
 
-        error, workspace, relative_path = self._validate_and_get_workspace_path(path)
+        error, workspace, relative_path = self.validate_and_get_workspace_path(path)
         if error:
             return json.dumps({'error': error})
 


### PR DESCRIPTION
This pull request makes a minor change to the `tool.py` file by renaming the `_validate_and_get_workspace_path` method to `validate_and_get_workspace_path` for consistency and clarity.

Code consistency improvements:

* [`src/agent_c_tools/src/agent_c_tools/tools/workspace/tool.py`](diffhunk://#diff-976a05154098ea3a00cfc53aced20fa20d459c68732d32a83c95a832e45b9fd2L118-R118): Replaced calls to `_validate_and_get_workspace_path` with `validate_and_get_workspace_path` in the `ls` and `internal_write_bytes` methods. [[1]](diffhunk://#diff-976a05154098ea3a00cfc53aced20fa20d459c68732d32a83c95a832e45b9fd2L118-R118) [[2]](diffhunk://#diff-976a05154098ea3a00cfc53aced20fa20d459c68732d32a83c95a832e45b9fd2L244-R244)