### PR TITLE
Adding UTF-8 read char error with replace.

### DIFF
--- a/src/agent_c_tools/src/agent_c_tools/tools/workspace/local_storage.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/workspace/local_storage.py
@@ -202,7 +202,7 @@ class LocalStorageWorkspace(BaseWorkspace):
                 raise FileNotFoundError(f'The path {file_path} does not exist.')
 
             if full_path.is_file():
-                with open(full_path, 'r', encoding='utf-8') as file:
+                with open(full_path, 'r', encoding='utf-8', errors='replace') as file:
                     return file.read()
             else:
                 return self._error_response(f'The path {file_path} is not a file.')


### PR DESCRIPTION
This pull request includes a small but important change to the `read_internal` method in `local_storage.py`. The change ensures that file reading operations handle encoding errors gracefully by replacing invalid characters.

* [`src/agent_c_tools/src/agent_c_tools/tools/workspace/local_storage.py`](diffhunk://#diff-4823fbec81d92cbc7dce6433774154eff330954f9fe968dbb02d3f1c4668164dL205-R205): Updated the `open` function in the `read_internal` method to include the `errors='replace'` parameter, which replaces invalid characters during file reading instead of raising an exception.