### PR TITLE
Fix missing dependency with front end

### DIFF
--- a/src/agent_c_api_ui/agent_c_react_client/package.json
+++ b/src/agent_c_api_ui/agent_c_react_client/package.json
@@ -22,6 +22,7 @@
     "@radix-ui/react-switch": "^1.1.3",
     "@radix-ui/react-tabs": "^1.1.3",
     "@radix-ui/react-tooltip": "^1.1.7",
+    "@rollup/rollup-win32-x64-msvc": "^4.40.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",


### PR DESCRIPTION
This pull request includes a small change to the `package.json` file for the `agent_c_react_client` project. The change adds the `@rollup/rollup-win32-x64-msvc` dependency with version `^4.40.0` to the list of dependencies.