### PR TITLE
fix imports

### DIFF
--- a/src/agent_c_tools/src/agent_c_tools/tools/workspace/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/workspace/tool.py
@@ -1,7 +1,7 @@
 import json
 import logging
 import re
-from typing import Any, List, Tuple, Optional
+from typing import Any, List, Tuple, Optional, Callable, Awaitable, Union
 from ts_tool import api
 
 from agent_c.toolsets.tool_set import Toolset


### PR DESCRIPTION
This pull request updates the imports in the `src/agent_c_tools/src/agent_c_tools/tools/workspace/tool.py` file to include additional type hints. The change expands the range of type annotations available for use within the file.

Key change:

* Updated the `typing` imports to include `Callable`, `Awaitable`, and `Union`, enabling more precise type annotations for functions and asynchronous operations.