### PR TITLE
Fix typo

### DIFF
--- a/src/agent_c_core/src/agent_c/toolsets/tool_chest.py
+++ b/src/agent_c_core/src/agent_c/toolsets/tool_chest.py
@@ -143,7 +143,7 @@ class ToolChest:
         self._update_toolset_metadata()
         return success
 
-    def dgit eactivate_toolset(self, toolset_name_or_names: Union[str, List[str]]) -> bool:
+    def deactivate_toolset(self, toolset_name_or_names: Union[str, List[str]]) -> bool:
         """
         Deactivate one or more toolsets by name.
         


### PR DESCRIPTION
This pull request includes a small fix to the `src/agent_c_core/src/agent_c/toolsets/tool_chest.py` file. The change corrects a typo in the method name `dgit eactivate_toolset` to `deactivate_toolset`, ensuring consistency and proper functionality.