### PR TITLE
Update tools that use the workspace to get it correctly using the tol…

### DIFF
--- a/src/agent_c_tools/src/agent_c_tools/tools/css_explorer/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/css_explorer/tool.py
@@ -19,7 +19,7 @@ class CssExplorerTools(Toolset):
         self.workspace_tool: Optional[WorkspaceTools] = None
 
     async def post_init(self):
-        self.workspace_tool = self.tool_chest.active_tools['workspace']
+        self.workspace_tool = self.tool_chest.active_tools['WorkspaceTools']
 
     @json_schema(
         'Obtain an overview of the CSS file structure and components. In a token efficient manner',

--- a/src/agent_c_tools/src/agent_c_tools/tools/dall_e/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/dall_e/tool.py
@@ -26,7 +26,7 @@ class DallETools(Toolset):
         if self.workspace is None:
             self.workspace_path = kwargs.get('dalle_workspace_path', os.environ.get('DALLE_IMAGE_SAVE_FOLDER', None))
             if self.workspace_path is not None:
-                self.workspace_tool: WorkspaceTools = cast(WorkspaceTools, self.tool_chest.active_tools.get('workspace'))
+                self.workspace_tool: WorkspaceTools = cast(WorkspaceTools, self.tool_chest.active_tools.get('WorkspaceTools'))
                 if self.workspace_tool is not None:
                     self.workspace = LocalStorageWorkspace(workspace_path=self.workspace_path, max_size=sys.maxsize)
                     self.workspace_tool.add_workspace(self.workspace)

--- a/src/agent_c_tools/src/agent_c_tools/tools/dynamics/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/dynamics/tool.py
@@ -236,7 +236,7 @@ class DynamicsTools(Toolset):
                 return json.dumps({"error": f"Error creating excel buffer bytes: {str(e)}\n\n{entities}"})
 
             # Write the file using the UNC path
-            result = await self.tool_chest.active_tools['workspace'].internal_write_bytes(
+            result = await self.tool_chest.active_tools['WorkspaceTools'].internal_write_bytes(
                 path=unc_path,
                 mode='write',
                 data=excel_buffer.getvalue()
@@ -249,7 +249,7 @@ class DynamicsTools(Toolset):
             display_path = file_path if file_path else '(root)'
 
             # Get the actual OS-level filepath using the workspace's full_path method
-            _, workspace_obj, rel_path = self.tool_chest.active_tools['workspace']._parse_unc_path(unc_path)
+            _, workspace_obj, rel_path = self.tool_chest.active_tools['WorkspaceTools']._parse_unc_path(unc_path)
             file_system_path = None
             if workspace_obj and hasattr(workspace_obj, 'full_path'):
                 # The full_path method handles path normalization and joining with workspace root

--- a/src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/tool.py
@@ -35,7 +35,7 @@ class MarkdownToHtmlReportTools(Toolset):
     def __init__(self, **kwargs):
         super().__init__(**kwargs, name="markdown_viewer", use_prefix=False)
         # Get workspace tools for file operations
-        self.workspace_tool = self.tool_chest.active_tools.get('workspace')
+        self.workspace_tool = self.tool_chest.active_tools.get('WorkspaceTools')
         if not self.workspace_tool:
             logger.warning("Workspace toolset not available. This tool requires workspace tools.")
 

--- a/src/agent_c_tools/src/agent_c_tools/tools/web/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/web/tool.py
@@ -209,7 +209,7 @@ class WebTools(Toolset):
                 file_path = f"{file_path}.md"
 
             # Get workspace toolset
-            workspace_tool = self.tool_chest.active_tools.get("workspace")
+            workspace_tool = self.tool_chest.active_tools.get("WorkspaceTools")
             if workspace_tool is None:
                 return json.dumps({
                     'error': "Workspace tool not available. Cannot save markdown.",

--- a/src/agent_c_tools/src/agent_c_tools/tools/xml_explorer/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/xml_explorer/tool.py
@@ -18,7 +18,7 @@ class XmlExplorerTools(Toolset):
         self.workspace_tool: Optional[WorkspaceTools] = None
 
     async def post_init(self):
-        self.workspace_tool = self.tool_chest.active_tools['workspace']
+        self.workspace_tool = self.tool_chest.active_tools['WorkspaceTools']
 
     @json_schema(
         'Get structure information about a large XML file without loading the entire file.',


### PR DESCRIPTION
This pull request standardizes the naming convention for accessing the `WorkspaceTools` object across multiple tools in the `agent_c_tools` module. The changes ensure consistency by replacing references to `'workspace'` with `'WorkspaceTools'` when accessing the `tool_chest.active_tools` dictionary.

### Standardization of `WorkspaceTools` references:

* Updated the `post_init` method in `css_explorer` to use `'WorkspaceTools'` instead of `'workspace'` when assigning `self.workspace_tool`. (`[src/agent_c_tools/src/agent_c_tools/tools/css_explorer/tool.pyL22-R22](diffhunk://#diff-90f24a328740d9157543600dcd667bee96520ef51c9436302935d3e8655c22a7L22-R22)`)
* Modified the `__init__` method in `dall_e` to cast and retrieve `'WorkspaceTools'` instead of `'workspace'` for `self.workspace_tool`. (`[src/agent_c_tools/src/agent_c_tools/tools/dall_e/tool.pyL29-R29](diffhunk://#diff-ba2b2565800bcbd4b12a19a297a2b0b0d6dbe3a59e15408e7065385dc75a6544L29-R29)`)
* Adjusted the `get_entities` method in `dynamics` to use `'WorkspaceTools'` for both `internal_write_bytes` and `_parse_unc_path` operations. (`[[1]](diffhunk://#diff-9adf02f8ad603fe2dd8e3438530690c23098a71fb8f915d55414215ad29db70aL239-R239)`, `[[2]](diffhunk://#diff-9adf02f8ad603fe2dd8e3438530690c23098a71fb8f915d55414215ad29db70aL252-R252)`)
* Updated the `MarkdownToHtmlReportTools` class to retrieve `'WorkspaceTools'` instead of `'workspace'` for `self.workspace_tool`. (`[src/agent_c_tools/src/agent_c_tools/tools/markdown_to_html_report/tool.pyL38-R38](diffhunk://#diff-5af3da31ce84f1fab1a804d56dc22834fafe3a83f0b3cb699074b862cbb65e68L38-R38)`)
* Changed the `fetch_and_save` method in `web` to fetch `'WorkspaceTools'` instead of `'workspace'` for file-saving operations. (`[src/agent_c_tools/src/agent_c_tools/tools/web/tool.pyL212-R212](diffhunk://#diff-1906871bc5bdabcc8a7b7cceb977bbb980e010f44eb12bd09a3b236e22c2aa9eL212-R212)`)
* Standardized the `post_init` method in `xml_explorer` to use `'WorkspaceTools'` when assigning `self.workspace_tool`. (`[src/agent_c_tools/src/agent_c_tools/tools/xml_explorer/tool.pyL21-R21](diffhunk://#diff-9e04c6deadcf2993fe750166b251ba8570b36e7cb8544830950a58dbde3abae0L21-R21)`)…l class name