### PR TITLE
Fix dyanmic person to fetch workspace properly now

### DIFF
--- a/src/agent_c_core/src/agent_c/prompting/basic_sections/persona.py
+++ b/src/agent_c_core/src/agent_c/prompting/basic_sections/persona.py
@@ -94,7 +94,7 @@ class DynamicPersonaSection(PromptSection):
         base_prompt = context.get("persona_prompt", "")
         ws_name = self._extract_workspace_name(base_prompt)
         if ws_name:
-            ws_tool = context['tool_chest'].active_tools.get('workspace')
+            ws_tool = context['tool_chest'].active_tools.get('WorkspaceTools')
 
             tree = await ws_tool.tree(path=f"//{ws_name}/", folder_depth=7, file_depth=5)
             context['workspace_tree'] = f"Generated: {self.timestamp()}\n{tree}"


### PR DESCRIPTION
This pull request includes a small change to the `rendered_persona_prompt` method in `persona.py`. The change updates the key used to retrieve the workspace tool from `tool_chest` to reflect a corrected or updated naming convention.

* [`src/agent_c_core/src/agent_c/prompting/basic_sections/persona.py`](diffhunk://#diff-7395d7a06588f54c8751a6861042068a9de0af646b8db59909cfcc9c3edf1b80L97-R97): Changed the key from `'workspace'` to `'WorkspaceTools'` when accessing `active_tools` in the `tool_chest` context.