### PR TITLE
Fix tools calls, add an export to the planner

### DIFF
--- a/src/agent_c_core/src/agent_c/agents/claude.py
+++ b/src/agent_c_core/src/agent_c/agents/claude.py
@@ -595,7 +595,7 @@ class ClaudeChatAgent(BaseAgent):
 
     async def __tool_calls_to_messages(self, state, tool_chest, tool_context):
         # Use the new centralized tool call handling in ToolChest
-        tools_calls = await tool_chest.call_tools(tool_calls, tool_context, format_type="claude")
+        tools_calls = await tool_chest.call_tools(state['collected_tool_calls'], tool_context, format_type="claude")
 
         return tools_calls
 

--- a/src/agent_c_tools/src/agent_c_tools/tools/workspace_planning/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/workspace_planning/tool.py
@@ -594,7 +594,7 @@ class WorkspacePlanningTools(Toolset):
         
         try:
             workspace_name, plan_id = self._parse_plan_path(plan_path)
-            plan = self._get_plan(plan_path)
+            plan = await self._get_plan(plan_path)
             
             if not plan:
                 return f"Plan not found at path: {plan_path}"


### PR DESCRIPTION
This pull request includes updates to asynchronous methods in the `agent_c` project to improve functionality and ensure consistency. The changes primarily involve modifying method calls to align with updated asynchronous patterns.

### Updates to asynchronous method calls:

* [`src/agent_c_core/src/agent_c/agents/claude.py`](diffhunk://#diff-d74867587f97368abcc0acaafc2f218509185212937c61d43c07a7fc5b791876L598-R598): Updated the `__tool_calls_to_messages` method to use `state['collected_tool_calls']` instead of the `tool_calls` parameter, ensuring the correct data is passed to the `ToolChest.call_tools` method.

* [`src/agent_c_tools/src/agent_c_tools/tools/workspace_planning/tool.py`](diffhunk://#diff-31898117c06d69eb03a8b2fb3146b943581c64421fd3d595982762d14e781318L597-R597): Modified the `export_plan_report` method to call `_get_plan` as an asynchronous function (`await self._get_plan(plan_path)`), ensuring proper handling of async operations.