### PR TITLE
Add MarkdownToHtmlReportTools to essential toolsets

### DIFF
--- a/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_bridge.py
+++ b/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_bridge.py
@@ -152,7 +152,7 @@ class AgentBridge:
         self.tool_cache = ToolCache(cache_dir=self.tool_cache_dir)
 
         if essential_tools is None:
-            self.essential_toolsets = ['WorkspaceTools', 'ThinkTools', "WorkspacePlanningTools"]
+            self.essential_toolsets = ['WorkspaceTools', 'ThinkTools', 'WorkspacePlanningTools', 'MarkdownToHtmlReportTools']
         else:
             self.essential_toolsets = essential_tools
         self.additional_toolsets = additional_tools or []


### PR DESCRIPTION
This pull request adds a new toolset to the list of essential tools in the `AgentBridge` class. 

### Changes to toolsets:
* Updated the `essential_toolsets` list in `AgentBridge` to include `'MarkdownToHtmlReportTools'`, ensuring support for converting Markdown to HTML reports. (`src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_bridge.py`, [src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_bridge.pyL155-R155](diffhunk://#diff-28bc5184f60b617647c44cd86d7e90885fee567cc04bad4bdf9ffda2f4e533d7L155-R155))
* The omission was causing the tool to neither be initialized, nor available in the UI.