### PR TITLE
Ignore the new events added for the logger in the ui

### DIFF
--- a/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_bridge.py
+++ b/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_bridge.py
@@ -964,6 +964,8 @@ class AgentBridge:
             "system_message": self._handle_system_message,
             "history_delta": self._ignore_event,
             "complete_thought": self._ignore_event,
+            "system_prompt": self._ignore_event,
+            "user_reequest": self._ignore_event,
         }
 
         handler = handlers.get(event.type)


### PR DESCRIPTION
This pull request introduces minor updates to the `consolidated_streaming_callback` method in `agent_bridge.py`. The changes add two new event types, `"system_prompt"` and `"user_reequest"`, to be ignored by the callback handler.

* [`src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_bridge.py`](diffhunk://#diff-28bc5184f60b617647c44cd86d7e90885fee567cc04bad4bdf9ffda2f4e533d7R967-R968): Added `"system_prompt"` and `"user_reequest"` to the list of event types handled by `_ignore_event`.