### PR TITLE
Remove essential tools from agent_manager.py as it was causing tools …

### DIFF
--- a/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_manager.py
+++ b/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_manager.py
@@ -29,7 +29,8 @@ class UItoAgentBridgeManager:
         ui_sessions (Dict[str, Dict[str, Any]]): Active session storage
         _locks (Dict[str, asyncio.Lock]): Session operation locks
     """
-    ESSENTIAL_TOOLS = ['WorkspaceTools', 'ThinkTools', 'RandomNumberTools', 'MarkdownToHtmlReportTools']
+    ESSENTIAL_TOOLS = []
+    # ESSENTIAL_TOOLS = ['WorkspaceTools', 'ThinkTools', 'RandomNumberTools', 'MarkdownToHtmlReportTools']
 
     def __init__(self):
         logging_manager = LoggingManager(__name__)


### PR DESCRIPTION
This pull request modifies the `ESSENTIAL_TOOLS` configuration in the `UItoAgentBridgeManager` class to temporarily disable the use of essential tools by setting the list to empty.

Configuration changes:

* [`src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/agent_manager.py`](diffhunk://#diff-2c4bb947c744aebea2a57649aee31da1fa01b19205514e829b50a624d228c2e7L32-R33): Updated the `ESSENTIAL_TOOLS` list to an empty list and commented out the original toolset (`WorkspaceTools`, `ThinkTools`, `RandomNumberTools`, `MarkdownToHtmlReportTools`).…to not be available for selection in the UI.  Essential tools are now primarily agent driven via agent config yaml files.