### PR TITLE
Prevent Agent context from being considered variables

### DIFF
--- a/agent_c_config/agents/douglas-bokf_design_orchetrator.yaml
+++ b/agent_c_config/agents/douglas-bokf_design_orchetrator.yaml
@@ -13,7 +13,6 @@ tools:
   - WorkspacePlanningTools
   - AgentTeamTools
   - AgentCloneTools
-  - AgentAssistTools
 agent_params:
   budget_tokens: 20000
   max_tokens: 64000

--- a/src/agent_c_tools/src/agent_c_tools/tools/agent_assist/prompt.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/agent_assist/prompt.py
@@ -28,7 +28,7 @@ class AssistantBehaviorSection(PromptSection):
         """
         context_str: Optional[str]  = prompt_context.get('process_context', None)
         if context_str:
-            return f"# Critical Process Context:\n\n{context_str}\n\n"
+            return f"# Critical Process Context:\n\n{context_str.replace('$', '$$')}\n\n"
         return ""
 
 

--- a/src/agent_c_tools/src/agent_c_tools/tools/agent_clone/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/agent_clone/tool.py
@@ -53,7 +53,7 @@ class AgentCloneTools(AgentAssistToolBase):
         clone_persona: str = calling_agent_config.persona
 
         if process_context:
-            enhanced_persona = f"# Clone Process Context and Instructions\n\n{process_context}\n\n# Base Agent Persona\n\n{clone_persona}"
+            enhanced_persona = f"# Clone Process Context and Instructions\n\n{process_context.replace('$', '$$')}\n\n# Base Agent Persona\n\n{clone_persona}"
         else:
             enhanced_persona =clone_persona
 
@@ -118,7 +118,7 @@ class AgentCloneTools(AgentAssistToolBase):
         clone_persona: str = calling_agent_config.persona
 
         if process_context:
-            enhanced_persona = f"# Clone Process Context and Instructions\n\n{process_context}\n\n# Base Agent Persona\n\n{clone_persona}"
+            enhanced_persona = f"# Clone Process Context and Instructions\n\n{process_context.replace('$', '$$')}\n\n# Base Agent Persona\n\n{clone_persona}"
         else:
             enhanced_persona = clone_persona
 


### PR DESCRIPTION
This pull request includes changes to improve string handling in various methods and updates to configuration files. The most significant updates involve escaping dollar signs in process context strings to prevent unintended behavior and removing an unused tool from the configuration.

### String Handling Improvements:
* [`src/agent_c_tools/src/agent_c_tools/tools/agent_assist/prompt.py`](diffhunk://#diff-eb80e308688009ce4ab4020fca80a45666f80cf807b052ef78a542f90072ec41L31-R31): Updated the `agent_process_directive` method to escape dollar signs in the `process_context` string using `.replace(', '$')`.
* [`src/agent_c_tools/src/agent_c_tools/tools/agent_clone/tool.py`](diffhunk://#diff-e1d28846f92318a2e8fc1c6f58af104f977b7433826589f6ccb8fede07298fceL56-R56): Updated the `oneshot` and `chat` methods to escape dollar signs in the `process_context` string using `.replace(', '$')`. [[1]](diffhunk://#diff-e1d28846f92318a2e8fc1c6f58af104f977b7433826589f6ccb8fede07298fceL56-R56) [[2]](diffhunk://#diff-e1d28846f92318a2e8fc1c6f58af104f977b7433826589f6ccb8fede07298fceL121-R121)

### Configuration Updates:
* [`agent_c_config/agents/douglas-bokf_design_orchetrator.yaml`](diffhunk://#diff-94fa72636d8acefbb6a685e8aeae0402e43ce10a36b8e150020c854825ad1358L16): Removed `AgentAssistTools` from the list of tools in the configuration, likely indicating it is no longer needed.