### PR TITLE
Ensure AA to AC tool handoff works

### DIFF
--- a/src/agent_c_tools/src/agent_c_tools/tools/agent_assist/base.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/agent_assist/base.py
@@ -140,11 +140,11 @@ class AgentAssistToolBase(Toolset):
         return chat_params | tool_params | agent_params
 
     @staticmethod
-    async def __build_prompt_metadata(agent: AgentConfiguration, user_session_id: Optional[str] = None, **opts) -> Dict[str, Any]:
-        agent_props = agent.prompt_metadata if agent.prompt_metadata else {}
+    async def __build_prompt_metadata(agent_config: AgentConfiguration, user_session_id: Optional[str] = None, **opts) -> Dict[str, Any]:
+        agent_props = agent_config.prompt_metadata if agent_config.prompt_metadata else {}
 
-        return {"session_id": user_session_id, "persona_prompt": agent.persona, "persona": agent.model_dump(exclude_none=True, exclude={'prompt_metadata'}),
-                "agent": agent,
+        return {"session_id": user_session_id, "persona_prompt": agent_config.persona,
+                "agent_config": agent_config,
                 "timestamp": datetime.now().isoformat()} | agent_props | opts
 
     async def agent_oneshot(self, user_message: str, agent: AgentConfiguration, user_session_id: Optional[str] = None,

--- a/src/agent_c_tools/src/agent_c_tools/tools/agent_assist/prompt.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/agent_assist/prompt.py
@@ -53,8 +53,8 @@ class AgentAssistSection(PromptSection):
 
     @property_bag_item
     async def agent_ids(self, prompt_context: Dict[str, Any]) -> str:
-        agent = prompt_context.get('active_agent', None)
-        available = self._filter_agent_catalog(agent)
+        agent_config = prompt_context.get('active_agent', prompt_context.get('agent_config', None))
+        available = self._filter_agent_catalog(agent_config)
         agent_descriptions = []
         for sub_agent in available:
             agent_descriptions.append(f"**{sub_agent.name}**, Agent Key: `{sub_agent.key}`\nTools:{", ".join(sub_agent.tools)}{sub_agent.agent_description}")


### PR DESCRIPTION
This pull request refactors variable naming for consistency and improves readability in the `agent_assist` module. The changes primarily involve renaming variables and updating references to align with the new naming conventions.

### Refactoring for consistency:

* [`src/agent_c_tools/src/agent_c_tools/tools/agent_assist/base.py`](diffhunk://#diff-0bba289e4bb4fa9c43eaa70e7440677a9854883688d01e559748cfd66cf8195aL143-R147): Renamed the `agent` parameter to `agent_config` in the `__build_prompt_metadata` method and updated all references accordingly. This ensures the variable name reflects its purpose more clearly.
* [`src/agent_c_tools/src/agent_c_tools/tools/agent_assist/prompt.py`](diffhunk://#diff-eb80e308688009ce4ab4020fca80a45666f80cf807b052ef78a542f90072ec41L56-R57): Updated the `agent` variable to `agent_config` in the `agent_ids` method to maintain consistency with the new naming convention. Adjusted logic to handle both `active_agent` and `agent_config` keys in the `prompt_context` dictionary.