### PR TITLE
Fix getting the root meta keys

### DIFF
--- a/src/agent_c_tools/src/agent_c_tools/tools/web/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/web/tool.py
@@ -133,7 +133,7 @@ class WebTools(Toolset):
             },
             'raw_output': {
                 'type': 'boolean',
-                'description': 'If true the raw content will be SAVED to the workspace',
+                'description': 'If true the raw content will be returned/saved',
                 'required': False
             },
             'max_tokens': {

--- a/src/agent_c_tools/src/agent_c_tools/tools/workspace/base.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/workspace/base.py
@@ -243,14 +243,15 @@ class BaseWorkspace:
         Returns:
              Any: The metadata value or and empty dict.
         """
-        key_parts = key.removeprefix('/').removeprefix('meta/').split('/')
         value = self._metadata
-        if len(key_parts):
-            for part in key_parts:
-                if isinstance(value, dict) and part in value:
-                    value = value[part]
-                else:
-                    value = None
+        if len(key) != 0 and key != '/' and key != 'meta':
+            key_parts = key.removeprefix('/').removeprefix('meta/').split('/')
+            if len(key_parts):
+                for part in key_parts:
+                    if isinstance(value, dict) and part in value:
+                        value = value[part]
+                    else:
+                        value = None
 
         # create a new dictionary without keys that start with '_'
         if not include_hidden and isinstance(value, dict):

--- a/src/agent_c_tools/src/agent_c_tools/tools/workspace/tool.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/workspace/tool.py
@@ -896,9 +896,8 @@ class WorkspaceTools(Toolset):
             value = await workspace.safe_metadata(key)
             if value is None:
                 self.logger.warning(f"Key '{key}' not found in metadata for workspace '{workspace.name}'")
-
-            if isinstance(value, dict):
-                response = yaml.dump(List(value.keys()), Dumper=yaml.Dumper, default_flow_style=False)
+            elif isinstance(value, dict):
+                response = self._yaml_dump(list(value.keys()))
                 token_count = tool_context['agent_runtime'].count_tokens(response)
                 if token_count > max_tokens:
                     return f"ERROR: Response exceeds max_tokens limit of {max_tokens}. Current token count: {token_count}."


### PR DESCRIPTION
This pull request includes updates to improve functionality and code clarity in the `agent_c_tools` package, specifically in metadata handling and content fetching. The most important changes include refining metadata key processing, improving YAML dumping for metadata keys, and clarifying the description of a configuration parameter.

### Metadata handling improvements:
* [`src/agent_c_tools/src/agent_c_tools/tools/workspace/base.py`](diffhunk://#diff-caa6471e2d1e0a64861682cba781a758c1a46454d5658a7fb609ff73d68b861dL246-R248): Added checks to ensure `key` is valid before processing it into parts, improving robustness in metadata key handling.
* [`src/agent_c_tools/src/agent_c_tools/tools/workspace/tool.py`](diffhunk://#diff-976a05154098ea3a00cfc53aced20fa20d459c68732d32a83c95a832e45b9fd2L899-R900): Replaced direct YAML dumping with a helper method `_yaml_dump`, enhancing code readability and maintainability.

### Content fetching clarification:
* [`src/agent_c_tools/src/agent_c_tools/tools/web/tool.py`](diffhunk://#diff-1906871bc5bdabcc8a7b7cceb977bbb980e010f44eb12bd09a3b236e22c2aa9eL136-R136): Updated the description of the `raw_output` parameter to clarify that raw content can both be returned and saved.