### PR TITLE
Add missing dep

### DIFF
--- a/src/agent_c_tools/pyproject.toml
+++ b/src/agent_c_tools/pyproject.toml
@@ -58,6 +58,7 @@ dependencies = [
     "linkedin-api==2.0.3", # linked_in
     "requests==2.32.3", # youtube
     "youtube_transcript_api==1.0.3", # YouTube_Transcript
+    "huggingface_hub==0.33.0"
 
 ]
 


### PR DESCRIPTION
This pull request adds a new dependency to the `src/agent_c_tools/pyproject.toml` file. The `huggingface_hub` library, version 0.33.0, is now included in the project's dependencies.