### PR TITLE
Fixed broken dockerfile build

### DIFF
--- a/dockerfiles/api.Dockerfile
+++ b/dockerfiles/api.Dockerfile
@@ -21,7 +21,6 @@ COPY docs /app/docs
 
 # Copy in the personas - right now we mount in docker-compose
 COPY agent_c_config /app/agent_c_config
-COPY personas /app/personas
 
 # Upgrade pip
 RUN pip install --no-cache-dir --upgrade pip


### PR DESCRIPTION
This pull request makes a small change to the `dockerfiles/api.Dockerfile` by removing the line that copies the `personas` directory into the Docker image. This change simplifies the Dockerfile, likely because the `personas` directory is no longer required in the image or is being handled differently.