### PR TITLE
Add workspace configuration for realtime client SDK in local_workspac…

### DIFF
--- a/local_workspaces.example.json
+++ b/local_workspaces.example.json
@@ -19,6 +19,11 @@
             "name": "ui",
             "workspace_path": "src/agent_c_api_ui/agent_c_react_client",
             "description": "Mapped to the source for the Agent C React UI"
+        },
+        {
+            "name": "realtime_client",
+            "workspace_path": "src/realtime_client",
+            "description": "Workspace for the realtime client SDK"
         }
     ]
 }


### PR DESCRIPTION
This pull request adds a new workspace configuration for the realtime client SDK to the example local workspaces file.

Workspace configuration:

* Added a new entry for the `realtime_client` workspace, specifying its path and description in `local_workspaces.example.json`.…es.example.json