### PR TITLE
Ensure websocket events get serviced  while chat is streaming

### DIFF
--- a/src/agent_c_core/src/agent_c/agents/claude.py
+++ b/src/agent_c_core/src/agent_c/agents/claude.py
@@ -1,3 +1,4 @@
+import asyncio
 import copy
 import json
 
@@ -287,6 +288,8 @@ class ClaudeChatAgent(BaseAgent):
 
                     await self._raise_history_event(messages, **callback_opts)
                     return  messages, state
+
+                await asyncio.sleep(0)
 
         return messages, state
 


### PR DESCRIPTION
This pull request introduces improvements to the agent interaction handling and streaming logic, focusing on better task management and responsiveness in the real-time bridge and Claude agent. The key changes include enhanced cancellation handling for user interactions and the addition of cooperative yielding in async event handlers to improve responsiveness.

#### Real-time bridge improvements

* Added logic to cancel any ongoing interaction when a new `TextInputEvent` is received, ensuring only one interaction is active at a time and preventing race conditions. The cancellation is handled gracefully using an event and `asyncio` task management. (`src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/realtime_bridge.py`)
* Inserted `await asyncio.sleep(0)` in the runtime callback to allow the event loop to yield and improve responsiveness during event handling. (`src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/realtime_bridge.py`)
* Removed unused `threading` import for code cleanliness. (`src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/realtime_bridge.py`)

#### Claude agent streaming improvements

* Added `await asyncio.sleep(0)` within the Claude streaming handler to yield control back to the event loop, improving streaming responsiveness. (`src/agent_c_core/src/agent_c/agents/claude.py`)
* Added missing `asyncio` import required for cooperative yielding. (`src/agent_c_core/src/agent_c/agents/claude.py`)…n claude.py for better responsiveness