### PR TITLE
Refactor send_avatar_list to handle missing heygen_client more clearly

### DIFF
--- a/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/realtime_bridge.py
+++ b/src/agent_c_api_ui/agent_c_api/src/agent_c_api/core/realtime_bridge.py
@@ -163,8 +163,11 @@ class RealtimeBridge(AgentBridge):
         await self.send_avatar_list()
 
     async def send_avatar_list(self) -> None:
-        resp = await self.heygen_client.list_avatars() if self.heygen_client else []
-        await self.send_event(AvatarListEvent(avatars=resp.data))
+        if self.heygen_client:
+            resp = await self.heygen_client.list_avatars()
+            await self.send_event(AvatarListEvent(avatars=resp.data))
+        else:
+            await self.send_event(AvatarListEvent(avatars=[]))
 
     async def end_avatar_session(self) -> None:
         """End the current avatar session if it exists"""


### PR DESCRIPTION
This pull request refactors the logic for sending the avatar list in the `realtime_bridge.py` file to improve clarity and ensure that the correct event is sent in all cases.

Error handling and event emission improvements:

* Refactored the `send_avatar_list` method to explicitly check for the presence of `heygen_client`, ensuring that `AvatarListEvent` is sent with either the fetched avatar data or an empty list if the client is not available.