### PR TITLE
Add directory exclusions to local storage grep command

### DIFF
--- a/src/agent_c_tools/src/agent_c_tools/tools/workspace/local_storage.py
+++ b/src/agent_c_tools/src/agent_c_tools/tools/workspace/local_storage.py
@@ -542,6 +542,10 @@ class LocalStorageWorkspace(BaseWorkspace):
                 cmd.append("-R")
             else:
                 cmd.append("-r")
+        excluded_dirs = ['.git', 'node_modules', '__pycache__', 'idea', '.vscode', '.venv', 'venv',
+                         'npm-cache', '.cache']
+        for ex_dir in excluded_dirs:
+            cmd.extend(["--exclude-dir", ex_dir])
 
         # Add pattern and files
         cmd.append(pattern)


### PR DESCRIPTION
This pull request updates the `grep` method in `local_storage.py` to improve search efficiency and relevance by excluding common directories that typically contain non-source or irrelevant files.

Improvements to search functionality:

* Added logic to exclude directories such as `.git`, `node_modules`, `__pycache__`, `idea`, `.vscode`, `.venv`, `venv`, `npm-cache`, and `.cache` from `grep` searches by appending `--exclude-dir` flags for each directory.…cessing